### PR TITLE
Add .NET .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# .NET build artifacts
+bin/
+obj/
+
+# Visual Studio files
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# Rider and Visual Studio folders
+.idea/
+.vs/
+
+# Packages
+packages/
+*.nupkg
+
+# Test results
+TestResults/
+
+# OS-generated files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add .gitignore with standard .NET build outputs and IDE files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efa10357483328d86c5e7c955a3cc