### PR TITLE
Improve RitualDataLoader error handling

### DIFF
--- a/src/Services/RitualDataLoadException.cs
+++ b/src/Services/RitualDataLoadException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Represents errors that occur during ritual data load operations.
+    /// </summary>
+    public class RitualDataLoadException : Exception
+    {
+        public RitualDataLoadException(string message, Exception? innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Services/RitualDataLoader.cs
+++ b/src/Services/RitualDataLoader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 using RitualOS.Models;
@@ -6,12 +7,37 @@ namespace RitualOS.Services
 {
     public static class RitualDataLoader
     {
-        public static RitualEntry LoadRitualFromJson(string filePath)
+        /// <summary>
+        /// Loads a ritual entry from a JSON file on disk.
+        /// </summary>
+        /// <param name="filePath">Path to the JSON file.</param>
+        /// <returns>The deserialized <see cref="RitualEntry"/>.</returns>
+        /// <exception cref="RitualDataLoadException">
+        /// Thrown when the file cannot be read or the JSON is invalid.
+        /// </exception>
+        public static RitualEntry? LoadRitualFromJson(string filePath)
         {
-            var json = File.ReadAllText(filePath);
-            return JsonSerializer.Deserialize<RitualEntry>(json);
+            if (!File.Exists(filePath))
+            {
+                throw new RitualDataLoadException($"File not found: {filePath}");
+            }
+
+            try
+            {
+                var json = File.ReadAllText(filePath);
+                return JsonSerializer.Deserialize<RitualEntry>(json);
+            }
+            catch (Exception ex) when (ex is IOException || ex is JsonException)
+            {
+                throw new RitualDataLoadException("Failed to deserialize ritual data.", ex);
+            }
         }
 
+        /// <summary>
+        /// Serializes a <see cref="RitualEntry"/> to the specified path in a pretty printed JSON format.
+        /// </summary>
+        /// <param name="entry">The ritual entry to save.</param>
+        /// <param name="filePath">File path where the JSON should be written.</param>
         public static void SaveRitualToJson(RitualEntry entry, string filePath)
         {
             var json = JsonSerializer.Serialize(entry, new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
## Summary
- make RitualDataLoader safer by checking file existence
- wrap JSON parsing in custom `RitualDataLoadException`
- document new behaviors with XML comments

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: Program does not contain a static Main method)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686efa07b39c83328ee49e1f9954e89f