### PR TITLE
Add dream schema and link docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ See the `/src` folder for code and `/samples` for example JSON files.
 This project targets **.NET 8** and uses **Avalonia UI** for its interface.
 A minimal project file is provided.
 
+## Documentation
+Schema references live in the `docs` folder:
+- [Ritual Schema](docs/ritual_schema.md)
+- [Inventory Schema](docs/inventory_schema.md)
+- [Client CRM Schema](docs/crm_schema.md)
+- [Dream Schema](docs/dream_schema.md)
+
+
 ## Pitch Deck
 A markdown pitch deck summarizing the vision can be found in `docs/pitch_deck.md`.
 

--- a/docs/dream_schema.md
+++ b/docs/dream_schema.md
@@ -1,0 +1,13 @@
+# Dream Schema
+
+```json
+{
+  "id": "string",
+  "date": "yyyy-mm-dd",
+  "title": "string",
+  "description": "string",
+  "symbols": ["string"],
+  "tags": ["string"],
+  "interpretations": "string"
+}
+```


### PR DESCRIPTION
## Summary
- document structure of dream logs
- list all schema docs in README for easy reference

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efa06aebc8332afa16a284e7c5ae9