### PR TITLE
CRM Ritual Linking

### DIFF
--- a/docs/crm_schema.md
+++ b/docs/crm_schema.md
@@ -2,12 +2,18 @@
 
 ```json
 {
+  "id": "string",
   "name": "string",
-  "email": "string",
   "role": "string",
-  "flags": ["string"],
+  "email": "string",
+  "phone": "string",
+  "notes": "string",
+  "ritual_history": [
+    { "id": "ritual_id" }
+  ],
   "tags": ["string"],
-  "ritual_ids": ["string"],
-  "energy_notes": "string"
+  "energy_notes": "string",
+  "created_at": "yyyy-mm-dd",
+  "last_updated": "yyyy-mm-dd"
 }
 ```

--- a/docs/ritual_schema.md
+++ b/docs/ritual_schema.md
@@ -13,6 +13,7 @@
   "ritual_steps": ["string"],
   "outcome_status": "pending|successful|failed|recurring",
   "tags": ["string"],
-  "notes": "string"
+  "notes": "string",
+  "client_id": "string"
 }
 ```

--- a/src/Models/ClientProfile.cs
+++ b/src/Models/ClientProfile.cs
@@ -1,15 +1,22 @@
+using System;
 using System.Collections.Generic;
 
 namespace RitualOS.Models
 {
     public class ClientProfile
     {
+        public string Id { get; set; }
         public string Name { get; set; }
-        public string Email { get; set; }
         public string Role { get; set; }
-        public List<string> Flags { get; set; } = new();
+        public string Email { get; set; }
+        public string Phone { get; set; }
+        public string Notes { get; set; }
+
+        public List<RitualEntry> RitualHistory { get; set; } = new();
         public List<string> Tags { get; set; } = new();
-        public List<string> RitualIds { get; set; } = new();
         public string EnergyNotes { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime LastUpdated { get; set; } = DateTime.Now;
     }
 }

--- a/src/Models/RitualEntry.cs
+++ b/src/Models/RitualEntry.cs
@@ -17,5 +17,6 @@ namespace RitualOS.Models
         public string OutcomeStatus { get; set; }
         public List<string> Tags { get; set; } = new();
         public string Notes { get; set; }
+        public string ClientId { get; set; }
     }
 }

--- a/src/Services/RitualDataLoader.cs
+++ b/src/Services/RitualDataLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using System.Collections.Generic;
 using RitualOS.Models;
 
 namespace RitualOS.Services
@@ -45,6 +46,40 @@ namespace RitualOS.Services
         {
             var json = JsonSerializer.Serialize(entry, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(filePath, json);
+        }
+
+        /// <summary>
+        /// Loads all ritual entries for a specific client from a directory of JSON files.
+        /// </summary>
+        /// <param name="directory">Directory containing ritual JSON files.</param>
+        /// <param name="clientId">ID of the client to filter by.</param>
+        /// <returns>List of rituals associated with the client.</returns>
+        public static List<RitualEntry> LoadRitualsForClient(string directory, string clientId)
+        {
+            var results = new List<RitualEntry>();
+
+            if (!Directory.Exists(directory))
+            {
+                return results;
+            }
+
+            foreach (var file in Directory.GetFiles(directory, "*.json"))
+            {
+                try
+                {
+                    var ritual = LoadRitualFromJson(file);
+                    if (ritual?.ClientId == clientId)
+                    {
+                        results.Add(ritual);
+                    }
+                }
+                catch (RitualDataLoadException)
+                {
+                    // ignore invalid files
+                }
+            }
+
+            return results;
         }
     }
 }

--- a/src/ViewModels/ClientViewModel.cs
+++ b/src/ViewModels/ClientViewModel.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using RitualOS.Models;
+
+namespace RitualOS.ViewModels
+{
+    /// <summary>
+    /// View model representing a client profile and their ritual history.
+    /// </summary>
+    public class ClientViewModel
+    {
+        public ClientProfile Client { get; }
+        public ObservableCollection<RitualEntry> Rituals { get; }
+
+        public ClientViewModel(ClientProfile client, IEnumerable<RitualEntry> rituals)
+        {
+            Client = client;
+            Rituals = new ObservableCollection<RitualEntry>(rituals.OrderByDescending(r => r.DatePerformed));
+        }
+
+        /// <summary>
+        /// Creates a new ritual pre-populated for this client and adds it to the history.
+        /// </summary>
+        public RitualEntry CreateNewRitual()
+        {
+            var ritual = new RitualEntry
+            {
+                Id = Guid.NewGuid().ToString(),
+                DateCreated = DateTime.Now,
+                DatePerformed = DateTime.Now,
+                ClientId = Client.Id
+            };
+
+            AddRitual(ritual);
+            return ritual;
+        }
+
+        /// <summary>
+        /// Adds a new ritual to this client and updates metadata.
+        /// </summary>
+        public void AddRitual(RitualEntry ritual)
+        {
+            ritual.ClientId = Client.Id;
+            Rituals.Add(ritual);
+            Client.RitualHistory.Add(ritual);
+            Client.LastUpdated = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Updates the notes field of the client.
+        /// </summary>
+        public void UpdateNotes(string notes)
+        {
+            Client.Notes = notes;
+            Client.LastUpdated = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Replace the client's tags with the provided set.
+        /// </summary>
+        public void UpdateTags(IEnumerable<string> tags)
+        {
+            Client.Tags = tags.ToList();
+            Client.LastUpdated = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Returns rituals optionally filtered by outcome or moon phase.
+        /// Results are sorted by performed date descending.
+        /// </summary>
+        public IEnumerable<RitualEntry> GetRituals(string? outcome = null, string? moonPhase = null)
+        {
+            var query = Rituals.AsEnumerable();
+
+            if (!string.IsNullOrWhiteSpace(outcome))
+            {
+                query = query.Where(r => string.Equals(r.OutcomeStatus, outcome, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!string.IsNullOrWhiteSpace(moonPhase))
+            {
+                query = query.Where(r => string.Equals(r.MoonPhase, moonPhase, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return query.OrderByDescending(r => r.DatePerformed);
+        }
+    }
+}

--- a/src/Views/ClientDetailView.axaml
+++ b/src/Views/ClientDetailView.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <TabControl>
+    <TabItem Header="Profile Info">
+      <StackPanel Margin="10" Spacing="4">
+        <TextBlock Text="{Binding Client.Name}"/>
+        <TextBlock Text="{Binding Client.Email}"/>
+        <TextBlock Text="{Binding Client.Phone}"/>
+        <TextBlock Text="{Binding Client.Role}"/>
+      </StackPanel>
+    </TabItem>
+    <TabItem Header="Ritual History">
+      <ListBox Items="{Binding Rituals}">
+        <ListBox.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding Title}"/>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </TabItem>
+    <TabItem Header="Energy Notes">
+      <TextBox Text="{Binding Client.EnergyNotes}" AcceptsReturn="True" Height="100"/>
+    </TabItem>
+  </TabControl>
+</UserControl>


### PR DESCRIPTION
## PR #XXX – CRM Ritual Linking
**Date:** 2025-07-10
**Author:** Justin Gargano
**Feature/Component Affected:** ClientProfile.cs, RitualEntry.cs, ClientViewModel.cs, RitualDataLoader.cs, ClientDetailView.axaml

---

### 🔧 Actions Taken:
- [x] Added ClientId linking and view model
- [x] Refactored data loader to filter by client
- [x] Fixed CRM schema documentation
- [x] Updated layout with new client detail view

---

### 📜 Intention Behind Changes:
Integrating clients with ritual history allows practitioners to see past work in one place and quickly create new sessions from an existing profile. This sets up future features like a global timeline and richer CRM tracking, further aligning with RitualOS's vision of unified spiritual management.

---

### 🧠 Notes for Future You:
Development occurred without a .NET runtime in the environment, so the build could not be verified. Once set up locally, ensure serialization of the new fields behaves as expected.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully (no)
- [ ] Manual UI tested
- [ ] Edge cases validated
- Known issues (if any): `dotnet` not installed


------
https://chatgpt.com/codex/tasks/task_e_686f21af71dc83329633185de94a159d