### PR TITLE
Add CRM interaction logging models

### DIFF
--- a/src/Models/ClientProfile.cs
+++ b/src/Models/ClientProfile.cs
@@ -13,6 +13,7 @@ namespace RitualOS.Models
         public string Notes { get; set; }
 
         public List<RitualEntry> RitualHistory { get; set; } = new();
+        public List<InteractionLogEntry> History { get; set; } = new();
         public List<string> Tags { get; set; } = new();
         public string EnergyNotes { get; set; }
 

--- a/src/Models/InteractionLogEntry.cs
+++ b/src/Models/InteractionLogEntry.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace RitualOS.Models
+{
+    public class InteractionLogEntry
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+        public string Type { get; set; }
+        public string Summary { get; set; }
+        public string Details { get; set; }
+    }
+}

--- a/src/Models/RitualEntry.cs
+++ b/src/Models/RitualEntry.cs
@@ -17,6 +17,7 @@ namespace RitualOS.Models
         public string OutcomeStatus { get; set; }
         public List<string> Tags { get; set; } = new();
         public string Notes { get; set; }
+        public Dictionary<string, string> CustomMetadata { get; set; } = new();
         public string ClientId { get; set; }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace RitualOS
+{
+    internal class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("RitualOS data models library");
+        }
+    }
+}

--- a/src/Services/RitualDataLoadException.cs
+++ b/src/Services/RitualDataLoadException.cs
@@ -17,9 +17,4 @@ namespace RitualOS.Services
         {
         }
     }
-        public RitualDataLoadException(string message, Exception? innerException = null)
-            : base(message, innerException)
-        {
-        }
-    }
 }

--- a/src/Views/ClientDetailView.axaml
+++ b/src/Views/ClientDetailView.axaml
@@ -9,7 +9,7 @@
       </StackPanel>
     </TabItem>
     <TabItem Header="Ritual History">
-      <ListBox Items="{Binding Rituals}">
+      <ListBox ItemsSource="{Binding Rituals}">
         <ListBox.ItemTemplate>
           <DataTemplate>
             <TextBlock Text="{Binding Title}"/>


### PR DESCRIPTION
## PR #XXX – Add CRM interaction logging models
**Date:** 2025-07-10
**Author:** Justin Gargano
**Feature/Component Affected:** ClientProfile.cs, RitualEntry.cs, InteractionLogEntry.cs, RitualDataLoadException.cs, Program.cs, ClientDetailView.axaml

---

### 🔧 Actions Taken:
- [x] Added InteractionLogEntry model for capturing contact history
- [x] Refactored ClientProfile and RitualEntry models to surface new fields
- [x] Fixed duplicate code in RitualDataLoadException
- [x] Added Program.cs entry point and corrected ListBox binding

---

### 📜 Intention Behind Changes:
Extending client profiles with an interaction log lets practitioners track every conversation or call alongside ritual history. This paves the way for richer CRM features and more context when reviewing a client’s journey within RitualOS.

---

### 🧠 Notes for Future You:
The repository still lacks a full UI, but adding a basic entry point allows `dotnet build` to compile cleanly. The Avalonia view binding was also corrected to avoid XAML parsing errors.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully (yes)
- [ ] Manual UI tested (n/a)
- [ ] Edge cases validated (none)
- Known issues: warnings remain for uninitialized nullable properties

------
https://chatgpt.com/codex/tasks/task_e_686f261feecc8332a3a8e6a6bbe0b256