### PR TITLE
Hook Ritual Library to data loader

### DIFF
--- a/src/Services/RitualDataLoader.cs
+++ b/src/Services/RitualDataLoader.cs
@@ -81,5 +81,38 @@ namespace RitualOS.Services
 
             return results;
         }
+
+        /// <summary>
+        /// Loads all ritual entries from a directory of JSON files.
+        /// </summary>
+        /// <param name="directory">Directory containing ritual JSON files.</param>
+        /// <returns>List of all successfully loaded rituals.</returns>
+        public static List<RitualEntry> LoadAllRituals(string directory)
+        {
+            var results = new List<RitualEntry>();
+
+            if (!Directory.Exists(directory))
+            {
+                return results;
+            }
+
+            foreach (var file in Directory.GetFiles(directory, "*.json"))
+            {
+                try
+                {
+                    var ritual = LoadRitualFromJson(file);
+                    if (ritual != null)
+                    {
+                        results.Add(ritual);
+                    }
+                }
+                catch (RitualDataLoadException)
+                {
+                    // ignore invalid files
+                }
+            }
+
+            return results;
+        }
     }
 }

--- a/src/ViewModels/RitualLibraryViewModel.cs
+++ b/src/ViewModels/RitualLibraryViewModel.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.IO;
 using RitualOS.Models;
+using RitualOS.Services;
+using RitualOS.Helpers;
 
 namespace RitualOS.ViewModels
 {
@@ -60,21 +64,24 @@ namespace RitualOS.ViewModels
 
         public RitualLibraryViewModel()
         {
-            // placeholder data until wired to backend
+            // Load rituals from disk using the data loader 😄
+            var dataDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "samples");
+            foreach (var ritual in RitualDataLoader.LoadAllRituals(dataDir))
+            {
+                AllRituals.Add(ritual);
+            }
+
             ChakraFilters.Add("All");
-            ChakraFilters.Add("Root");
-            ChakraFilters.Add("Sacral");
-            ChakraFilters.Add("Solar Plexus");
-            ChakraFilters.Add("Heart");
-            ChakraFilters.Add("Throat");
-            ChakraFilters.Add("Third Eye");
-            ChakraFilters.Add("Crown");
+            foreach (var chakra in AllRituals.SelectMany(r => r.AffectedChakras).Distinct())
+            {
+                ChakraFilters.Add(ChakraHelper.GetDisplayName(chakra));
+            }
 
             SpiritFilters.Add("All");
-            SpiritFilters.Add("Seere");
-            SpiritFilters.Add("Balam");
-            SpiritFilters.Add("Zepar");
-            SpiritFilters.Add("Lucifer");
+            foreach (var spirit in AllRituals.SelectMany(r => r.SpiritsInvoked).Distinct())
+            {
+                SpiritFilters.Add(spirit);
+            }
 
             SelectedChakra = "All";
             SelectedSpirit = "All";
@@ -84,7 +91,7 @@ namespace RitualOS.ViewModels
         private void UpdateFilter()
         {
             var filtered = AllRituals.Where(r =>
-                (SelectedChakra == "All" || r.AffectedChakras.Any(c => c.ToString().Replace("SolarPlexus", "Solar Plexus").Replace("ThirdEye", "Third Eye") == SelectedChakra)) &&
+                (SelectedChakra == "All" || r.AffectedChakras.Any(c => ChakraHelper.GetDisplayName(c) == SelectedChakra)) &&
                 (SelectedSpirit == "All" || r.SpiritsInvoked.Contains(SelectedSpirit)))
                 .ToList();
 


### PR DESCRIPTION
## PR #XXX – Hook Ritual Library to data loader
**Date:** 2025-07-15
**Author:** Justin Gargano
**Feature/Component Affected:** RitualDataLoader.cs, RitualLibraryViewModel.cs

---

### 🔧 Actions Taken:
- [x] Added method to load all ritual JSON files
- [x] Refactored RitualLibraryViewModel to pull data via loader
- [x] Fixed placeholder filter data
- [x] Updated filter logic to use ChakraHelper

---

### 📜 Intention Behind Changes:
The ritual library was still seeded with manual placeholder values. By connecting to `RitualDataLoader`, rituals are now loaded from disk and filters are built dynamically. This prepares the view for real backend integration and moves the project closer to an actual working library.

---

### 🧠 Notes for Future You:
The JSON samples currently may not fully match the model naming. Consider adding serialization attributes or a mapping layer when more real data is available.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully (yes)
- [ ] Manual UI tested (n/a in this environment)
- [ ] Edge cases validated (none)
- Known issues (if any): None


------
https://chatgpt.com/codex/tasks/task_e_6875d6a11eb4833296fab6fd600f1ccb