### PR TITLE
Add ritual builder and editor stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ inventory of magical ingredients, log dreams, and manage clients.
 - Basic client CRM for session notes and ritual history
 - Calendar timeline to review past rituals
 - Offline-first JSON storage with simple import/export
+- Ritual creation wizard for step-by-step template building
+- Symbol index editor with chakra tagging
+- Codex rewrite preview tool
+- Dashboard view for client profiles
 
 ## Project Structure
 See the `/src` folder for code and `/samples` for example JSON files.

--- a/src/Models/RitualWizardStep.cs
+++ b/src/Models/RitualWizardStep.cs
@@ -1,0 +1,17 @@
+namespace RitualOS.Models
+{
+    /// <summary>
+    /// Steps in the ritual creation wizard.
+    /// </summary>
+    public enum RitualWizardStep
+    {
+        Tools,
+        Steps,
+        Spirits,
+        Ingredients,
+        Incantations,
+        Thanks,
+        Chakras,
+        Review
+    }
+}

--- a/src/Models/Symbol.cs
+++ b/src/Models/Symbol.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace RitualOS.Models
 {
     /// <summary>
@@ -10,5 +12,7 @@ namespace RitualOS.Models
         public string Rewritten { get; set; }
         public string RitualText { get; set; }
         public string Description { get; set; }
+        public List<Chakra> ChakraTags { get; set; } = new();
+        public List<string> ElementTags { get; set; } = new();
     }
 }

--- a/src/Services/ClientProfileLoader.cs
+++ b/src/Services/ClientProfileLoader.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Helper methods for loading and saving <see cref="ClientProfile"/> objects.
+    /// </summary>
+    public static class ClientProfileLoader
+    {
+        /// <summary>
+        /// Loads all client profiles from the specified directory.
+        /// </summary>
+        /// <param name="directory">Directory path containing JSON client files.</param>
+        public static List<ClientProfile> LoadClients(string directory)
+        {
+            var results = new List<ClientProfile>();
+            if (!Directory.Exists(directory))
+            {
+                return results;
+            }
+
+            foreach (var file in Directory.GetFiles(directory, "*.json"))
+            {
+                try
+                {
+                    var json = File.ReadAllText(file);
+                    var profile = JsonSerializer.Deserialize<ClientProfile>(json);
+                    if (profile != null)
+                    {
+                        results.Add(profile);
+                    }
+                }
+                catch (Exception)
+                {
+                    // ignore invalid client files
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Saves the provided client profile to a JSON file in the directory.
+        /// </summary>
+        public static void SaveClient(ClientProfile profile, string directory)
+        {
+            Directory.CreateDirectory(directory);
+            var filePath = Path.Combine(directory, $"{profile.Id}.json");
+            var json = JsonSerializer.Serialize(profile, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(filePath, json);
+        }
+    }
+}

--- a/src/Services/SymbolIndexService.cs
+++ b/src/Services/SymbolIndexService.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Provides loading and saving functionality for SymbolIndex.json.
+    /// </summary>
+    public static class SymbolIndexService
+    {
+        public const string FileName = "SymbolIndex.json";
+
+        /// <summary>
+        /// Loads the symbol index from disk, returning an empty list if missing.
+        /// </summary>
+        public static List<Symbol> Load()
+        {
+            if (!File.Exists(FileName))
+            {
+                return new List<Symbol>();
+            }
+
+            var json = File.ReadAllText(FileName);
+            return JsonSerializer.Deserialize<List<Symbol>>(json) ?? new List<Symbol>();
+        }
+
+        /// <summary>
+        /// Saves the provided symbols to disk.
+        /// </summary>
+        public static void Save(IEnumerable<Symbol> symbols)
+        {
+            var json = JsonSerializer.Serialize(symbols, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(FileName, json);
+        }
+    }
+}

--- a/src/ViewModels/Wizards/ClientProfileDashboardViewModel.cs
+++ b/src/ViewModels/Wizards/ClientProfileDashboardViewModel.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using RitualOS.Services;
+using RitualOS.Models;
+
+namespace RitualOS.ViewModels.Wizards
+{
+    /// <summary>
+    /// Dashboard presenting multiple client timelines.
+    /// </summary>
+    public class ClientProfileDashboardViewModel : ViewModelBase
+    {
+        public ObservableCollection<ClientViewModel> Clients { get; } = new();
+
+        public ClientProfileDashboardViewModel()
+        {
+            foreach (var client in ClientProfileLoader.LoadClients("clients"))
+            {
+                var rituals = RitualDataLoader.LoadRitualsForClient("rituals", client.Id);
+                Clients.Add(new ClientViewModel(client, rituals));
+            }
+        }
+    }
+}

--- a/src/ViewModels/Wizards/CodexRewritePreviewerViewModel.cs
+++ b/src/ViewModels/Wizards/CodexRewritePreviewerViewModel.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using System.Windows.Input;
+using RitualOS.Helpers;
+using RitualOS.Models;
+using RitualOS.Services;
+
+namespace RitualOS.ViewModels.Wizards
+{
+    /// <summary>
+    /// View model for rewriting codex entries with preview.
+    /// </summary>
+    public class CodexRewritePreviewerViewModel : ViewModelBase
+    {
+        private string _original = string.Empty;
+        private string _rewrite = string.Empty;
+        private string _analysis = string.Empty;
+        private Symbol? _symbol;
+
+        public Symbol? Symbol
+        {
+            get => _symbol;
+            set
+            {
+                if (_symbol != value)
+                {
+                    _symbol = value;
+                    if (_symbol != null)
+                    {
+                        Original = _symbol.Original;
+                        Rewrite = _symbol.Rewritten;
+                    }
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Original
+        {
+            get => _original;
+            set
+            {
+                if (_original != value)
+                {
+                    _original = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Rewrite
+        {
+            get => _rewrite;
+            set
+            {
+                if (_rewrite != value)
+                {
+                    _rewrite = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ChakraAnalysis
+        {
+            get => _analysis;
+            set
+            {
+                if (_analysis != value)
+                {
+                    _analysis = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ICommand SaveCommand { get; }
+
+        public CodexRewritePreviewerViewModel()
+        {
+            SaveCommand = new RelayCommand(_ => Save(), _ => Symbol != null);
+        }
+
+        private void Save()
+        {
+            if (Symbol == null)
+                return;
+
+            Symbol.Original = Original;
+            Symbol.Rewritten = Rewrite;
+            Symbol.RitualText = ChakraAnalysis;
+
+            var symbols = SymbolIndexService.Load();
+            var existing = symbols.FirstOrDefault(s => s.Name == Symbol.Name);
+            if (existing != null)
+            {
+                symbols.Remove(existing);
+            }
+            symbols.Add(Symbol);
+            SymbolIndexService.Save(symbols);
+        }
+    }
+}

--- a/src/ViewModels/Wizards/RitualTemplateBuilderViewModel.cs
+++ b/src/ViewModels/Wizards/RitualTemplateBuilderViewModel.cs
@@ -1,0 +1,72 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using RitualOS.Helpers;
+using RitualOS.Models;
+using RitualOS.Services;
+
+namespace RitualOS.ViewModels.Wizards
+{
+    /// <summary>
+    /// View model for the ritual creation wizard.
+    /// </summary>
+    public class RitualTemplateBuilderViewModel : ViewModelBase
+    {
+        private RitualWizardStep _step = RitualWizardStep.Tools;
+        public RitualWizardStep Step
+        {
+            get => _step;
+            set
+            {
+                if (_step != value)
+                {
+                    _step = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public RitualEntry Ritual { get; } = new();
+
+        public ICommand NextCommand { get; }
+        public ICommand PrevCommand { get; }
+        public ICommand SaveCommand { get; }
+        public ICommand AddSpiritCommand { get; }
+        public ICommand AddIngredientCommand { get; }
+
+        public ObservableCollection<string> Spirits { get; } = new();
+        public ObservableCollection<string> Ingredients { get; } = new();
+
+        public RitualTemplateBuilderViewModel()
+        {
+            NextCommand = new RelayCommand(_ => MoveNext(), _ => Step != RitualWizardStep.Review);
+            PrevCommand = new RelayCommand(_ => MovePrev(), _ => Step != RitualWizardStep.Tools);
+            SaveCommand = new RelayCommand(_ => Save());
+            AddSpiritCommand = new RelayCommand(_ => Spirits.Add(string.Empty));
+            AddIngredientCommand = new RelayCommand(_ => Ingredients.Add(string.Empty));
+        }
+
+        private void MoveNext()
+        {
+            if (Step < RitualWizardStep.Review)
+            {
+                Step++;
+            }
+        }
+
+        private void MovePrev()
+        {
+            if (Step > RitualWizardStep.Tools)
+            {
+                Step--;
+            }
+        }
+
+        private void Save()
+        {
+            Ritual.SpiritsInvoked = Spirits.ToList();
+            Ritual.Ingredients = Ingredients.ToList();
+            RitualDataLoader.SaveRitualToJson(Ritual, $"{Ritual.Id}.json");
+        }
+    }
+}

--- a/src/ViewModels/Wizards/SymbolIndexBuilderViewModel.cs
+++ b/src/ViewModels/Wizards/SymbolIndexBuilderViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using RitualOS.Helpers;
+using RitualOS.Models;
+using RitualOS.Services;
+
+namespace RitualOS.ViewModels.Wizards
+{
+    /// <summary>
+    /// View model for editing SymbolIndex.json.
+    /// </summary>
+    public class SymbolIndexBuilderViewModel : ViewModelBase
+    {
+        public ObservableCollection<Symbol> Symbols { get; } = new();
+
+        public ICommand SaveCommand { get; }
+        public ICommand AddCommand { get; }
+
+        public SymbolIndexBuilderViewModel()
+        {
+            SaveCommand = new RelayCommand(_ => Save());
+            AddCommand = new RelayCommand(_ => AddSymbol());
+
+            // Load existing symbols from disk when the editor opens
+            foreach (var symbol in SymbolIndexService.Load())
+            {
+                Symbols.Add(symbol);
+            }
+        }
+
+        private void Save()
+        {
+            SymbolIndexService.Save(Symbols.ToList());
+        }
+
+        private void AddSymbol()
+        {
+            Symbols.Add(new Symbol());
+        }
+    }
+}

--- a/src/Views/Wizards/ClientProfileDashboard.axaml
+++ b/src/Views/Wizards/ClientProfileDashboard.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StackPanel Margin="20" Spacing="8">
+    <TextBlock Text="Client Dashboard" FontWeight="Bold"/>
+    <ListBox ItemsSource="{Binding Clients}">
+      <ListBox.ItemTemplate>
+        <DataTemplate>
+          <TextBlock Text="{Binding Client.Name}"/>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+  </StackPanel>
+</UserControl>

--- a/src/Views/Wizards/CodexRewritePreviewer.axaml
+++ b/src/Views/Wizards/CodexRewritePreviewer.axaml
@@ -1,0 +1,9 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StackPanel Margin="20" Spacing="6">
+    <TextBlock Text="Codex Rewrite Preview" FontWeight="Bold"/>
+    <TextBox Text="{Binding Original}" AcceptsReturn="True" Watermark="Original" Height="80"/>
+    <TextBox Text="{Binding Rewrite}" AcceptsReturn="True" Watermark="Rewrite" Height="80"/>
+    <TextBox Text="{Binding ChakraAnalysis}" AcceptsReturn="True" Watermark="Chakra Analysis" Height="60"/>
+    <Button Content="Save" Command="{Binding SaveCommand}"/>
+  </StackPanel>
+</UserControl>

--- a/src/Views/Wizards/RitualTemplateBuilder.axaml
+++ b/src/Views/Wizards/RitualTemplateBuilder.axaml
@@ -1,0 +1,20 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StackPanel Margin="20" Spacing="8">
+    <TextBlock Text="{Binding Step}" FontWeight="Bold"/>
+    <StackPanel Orientation="Horizontal" Spacing="6">
+      <StackPanel>
+        <ListBox ItemsSource="{Binding Spirits}" Width="120" Height="80"/>
+        <Button Content="Add Spirit" Command="{Binding AddSpiritCommand}"/>
+      </StackPanel>
+      <StackPanel>
+        <ListBox ItemsSource="{Binding Ingredients}" Width="120" Height="80"/>
+        <Button Content="Add Ingredient" Command="{Binding AddIngredientCommand}"/>
+      </StackPanel>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Spacing="6">
+      <Button Content="Prev" Command="{Binding PrevCommand}"/>
+      <Button Content="Next" Command="{Binding NextCommand}"/>
+      <Button Content="Save" Command="{Binding SaveCommand}"/>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/src/Views/Wizards/SymbolIndexBuilder.axaml
+++ b/src/Views/Wizards/SymbolIndexBuilder.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StackPanel Margin="20" Spacing="8">
+    <TextBlock Text="Symbol Index Builder" FontWeight="Bold"/>
+    <ListBox ItemsSource="{Binding Symbols}" Height="100">
+      <ListBox.ItemTemplate>
+        <DataTemplate>
+          <TextBox Text="{Binding Name}" Width="120"/>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+    <StackPanel Orientation="Horizontal" Spacing="6">
+      <Button Content="Add" Command="{Binding AddCommand}"/>
+      <Button Content="Save" Command="{Binding SaveCommand}"/>
+    </StackPanel>
+  </StackPanel>
+</UserControl>


### PR DESCRIPTION
## PR #XXX – Improve wizard utilities
**Date:** 2025-07-15
**Author:** Justin Gargano
**Feature/Component Affected:** ClientProfileLoader.cs, SymbolIndexService.cs, RitualTemplateBuilderViewModel.cs, SymbolIndexBuilderViewModel.cs

---

### 🔧 Actions Taken:
- [x] Created services for loading/saving clients and symbol index
- [x] Wired symbol index editor to disk storage and add button
- [x] Expanded ritual builder to persist rituals and manage lists
- [x] Enhanced codex previewer and dashboard with real data hooks

---

### 📜 Intention Behind Changes:
These updates flesh out the previously stubbed wizard components. They provide concrete data loading and saving to move RitualOS toward a functional workflow for client management, symbol tagging, and ritual templates.

---

### 🧠 Notes for Future You:
Further UI polish and error handling would make these tools production-ready. Currently they assume a `clients` and `rituals` folder exists.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully (yes)
- [ ] Manual UI tested (n/a)
- [ ] Edge cases validated (n/a)
- Known issues: none


------
https://chatgpt.com/codex/tasks/task_e_6875d74bed008332985f68cd760b9355