### PR TITLE
Add client database service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ inventory of magical ingredients, log dreams, and manage clients.
 - Inventory tracking with expiration and reorder alerts
 - Dream journal with symbolic tagging
 - Basic client CRM for session notes and ritual history
+- File-backed **ClientDatabase** service for storing and searching clients
 - Calendar timeline to review past rituals
 - Offline-first JSON storage with simple import/export
 

--- a/docs/crm_schema.md
+++ b/docs/crm_schema.md
@@ -17,3 +17,6 @@
   "last_updated": "yyyy-mm-dd"
 }
 ```
+
+Client records are stored as individual JSON files. They can be looked up by `id` and linked to
+rituals using the `ClientDatabase` service which manages persistence and beneficiary assignment.

--- a/src/Services/ClientDatabase.cs
+++ b/src/Services/ClientDatabase.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Simple file-backed database for storing and retrieving <see cref="ClientProfile"/> records.
+    /// Clients can also be assigned as ritual beneficiaries.
+    /// </summary>
+    public class ClientDatabase
+    {
+        private readonly Dictionary<string, ClientProfile> _clients = new();
+        private readonly string _storageDirectory;
+
+        /// <summary>
+        /// Initializes the database and loads any existing client JSON files from the directory.
+        /// </summary>
+        /// <param name="storageDirectory">Directory where client files are stored.</param>
+        public ClientDatabase(string storageDirectory)
+        {
+            _storageDirectory = storageDirectory;
+            LoadClients();
+        }
+
+        /// <summary>
+        /// Returns a client profile by id, or <c>null</c> if it does not exist.
+        /// </summary>
+        public ClientProfile? GetClient(string id)
+        {
+            _clients.TryGetValue(id, out var client);
+            return client;
+        }
+
+        /// <summary>
+        /// Adds or updates a client record and writes it to disk.
+        /// </summary>
+        public void SaveClient(ClientProfile client)
+        {
+            if (string.IsNullOrWhiteSpace(client.Id))
+            {
+                client.Id = Guid.NewGuid().ToString();
+            }
+
+            client.LastUpdated = DateTime.Now;
+            _clients[client.Id] = client;
+
+            var path = Path.Combine(_storageDirectory, $"{client.Id}.json");
+            var json = JsonSerializer.Serialize(client, new JsonSerializerOptions { WriteIndented = true });
+            Directory.CreateDirectory(_storageDirectory);
+            File.WriteAllText(path, json);
+        }
+
+        /// <summary>
+        /// Searches clients by case-insensitive name fragment.
+        /// </summary>
+        public IEnumerable<ClientProfile> FindByName(string nameFragment)
+        {
+            return _clients.Values.Where(c => c.Name.Contains(nameFragment, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Links the specified client as a beneficiary of the ritual and updates the client's history.
+        /// </summary>
+        public void AddClientAsBeneficiary(string clientId, RitualEntry ritual)
+        {
+            ritual.ClientId = clientId;
+
+            if (_clients.TryGetValue(clientId, out var client))
+            {
+                client.RitualsPerformed.Add(ritual);
+                client.LastUpdated = DateTime.Now;
+                SaveClient(client);
+            }
+        }
+
+        private void LoadClients()
+        {
+            if (!Directory.Exists(_storageDirectory))
+            {
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(_storageDirectory, "*.json"))
+            {
+                try
+                {
+                    var json = File.ReadAllText(file);
+                    var client = JsonSerializer.Deserialize<ClientProfile>(json);
+                    if (client?.Id != null)
+                    {
+                        _clients[client.Id] = client;
+                    }
+                }
+                catch
+                {
+                    // ignore malformed files
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR #XXX – Customer CRM Database
**Date:** 2024-06-14
**Author:** Justin Gargano
**Feature/Component Affected:** ClientDatabase.cs, docs

---

### 🔧 Actions Taken:
- [x] Added ClientDatabase service for storing and searching clients
- [x] Updated CRM schema documentation
- [x] Mentioned ClientDatabase in README

---

### 📜 Intention Behind Changes:
Provides a simple file-backed repository so clients can be persisted, looked up, and assigned as beneficiaries for rituals.

---

### 🧠 Notes for Future You:
The service currently loads/saves JSON per client. Consider adding batch operations if the dataset grows.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully
- [ ] Manual UI tested (n/a)
- [ ] Edge cases validated


------
https://chatgpt.com/codex/tasks/task_e_6876402f042c8332b04bfacf3de79d1e