### PR TITLE
Expand ritual template builder and role context

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -56,6 +56,7 @@
     <Compile Include="src\Services\RitualDataLoadException.cs" />
     <Compile Include="src\Services\SymbolIndexService.cs" />
     <Compile Include="src\Services\SigilLock.cs" />
+    <Compile Include="src\Services\UserContext.cs" />
     <Compile Include="src\Services\RitualTemplateSerializer.cs" />
     <Compile Include="src\Services\ThemeLoader.cs" />
     <Compile Include="src\ViewModels\ClientViewModel.cs" />

--- a/src/Services/UserContext.cs
+++ b/src/Services/UserContext.cs
@@ -1,0 +1,13 @@
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Provides a simple way to store the current user's role.
+    /// In the future this could load from settings or authentication.
+    /// </summary>
+    public static class UserContext
+    {
+        public static Role CurrentRole { get; set; } = Role.Ritualist;
+    }
+}

--- a/src/Views/Wizards/RitualTemplateBuilder.axaml
+++ b/src/Views/Wizards/RitualTemplateBuilder.axaml
@@ -1,20 +1,24 @@
 <UserControl xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Margin="20" Spacing="8">
-    <TextBlock Text="{Binding Step}" FontWeight="Bold"/>
-    <StackPanel Orientation="Horizontal" Spacing="6">
-      <StackPanel>
-        <ListBox ItemsSource="{Binding Spirits}" Width="120" Height="80"/>
-        <Button Content="Add Spirit" Command="{Binding AddSpiritCommand}"/>
-      </StackPanel>
-      <StackPanel>
-        <ListBox ItemsSource="{Binding Tools}" Width="120" Height="80"/>
-        <Button Content="Add Tool" Command="{Binding AddToolCommand}"/>
+  <Grid ColumnDefinitions="2*,*" RowDefinitions="Auto,*" Margin="10">
+    <StackPanel Grid.Column="0" Spacing="6" IsEnabled="{Binding CanEdit}">
+      <TextBlock Text="Ritual Template" FontSize="18" FontWeight="Bold"/>
+      <TextBox Watermark="Name" Text="{Binding Template.Name}"/>
+      <TextBox Watermark="Intention" Text="{Binding Template.Intention}" AcceptsReturn="True" Height="60"/>
+      <TextBlock Text="Spirits" FontWeight="Bold"/>
+      <ListBox ItemsSource="{Binding Spirits}" Height="80"/>
+      <Button Content="Add Spirit" Command="{Binding AddSpiritCommand}"/>
+      <TextBlock Text="Tools" FontWeight="Bold" Margin="0,10,0,0"/>
+      <ListBox ItemsSource="{Binding Tools}" Height="80"/>
+      <Button Content="Add Tool" Command="{Binding AddToolCommand}"/>
+      <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,10,0,0">
+        <Button Content="Prev" Command="{Binding PrevCommand}"/>
+        <Button Content="Next" Command="{Binding NextCommand}"/>
+        <Button Content="Save" Command="{Binding SaveCommand}"/>
+        <Button Content="Load" Command="{Binding LoadCommand}"/>
       </StackPanel>
     </StackPanel>
-    <StackPanel Orientation="Horizontal" Spacing="6">
-      <Button Content="Prev" Command="{Binding PrevCommand}"/>
-      <Button Content="Next" Command="{Binding NextCommand}"/>
-      <Button Content="Save" Command="{Binding SaveCommand}"/>
-    </StackPanel>
-  </StackPanel>
+    <ScrollViewer Grid.Column="1" Margin="10">
+      <TextBox Text="{Binding Preview}" AcceptsReturn="True" IsReadOnly="True"/>
+    </ScrollViewer>
+  </Grid>
 </UserControl>


### PR DESCRIPTION
## PR #34 – Expand ritual template builder
**Date:** 2025-07-16
**Author:** Justin Gargano
**Feature/Component Affected:** RitualTemplateBuilderViewModel.cs, RitualTemplateBuilder.axaml, UserContext.cs, RitualOS.csproj

---

### 🔧 Actions Taken:
- [x] Added new `UserContext` service for storing the active role
- [x] Refactored builder view and view model to include preview and load command
- [x] Fixed feature gating via `SigilLock` with `CanEdit` property
- [x] Updated project file to include new class

---

### 📜 Intention Behind Changes:
Lays more groundwork from `RitualOS_TODO.md` by expanding the ritual template system with a two-panel editor and JSON preview. The builder now respects role-based feature control so certain roles can be restricted from editing.

---

### 🧠 Notes for Future You:
The UI is still basic—no fancy tag controls yet. Future iterations should wire up file dialogs and richer validation once more components are in place.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully
- [ ] Manual UI tested (N/A in this environment)
- [ ] Edge cases validated (N/A)
- Known issues (if any): None


------
https://chatgpt.com/codex/tasks/task_e_6877e0c0a5488332b68eba14a9c186db