### PR TITLE
Add element selector and dream element support

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -27,10 +27,12 @@
     <Compile Include="src\Program.cs" />
     <Compile Include="src\Converters\ChakraCheckConverter.cs" />
     <Compile Include="src\Converters\ChakraToEmojiConverter.cs" />
+    <Compile Include="src\Converters\ElementCheckConverter.cs" />
     <Compile Include="src\Converters\LowQuantityConverter.cs" />
     <Compile Include="src\Converters\MessageColorConverter.cs" />
     <Compile Include="src\Converters\StringListConverter.cs" />
     <Compile Include="src\Helpers\ChakraHelper.cs" />
+    <Compile Include="src\Helpers\ElementHelper.cs" />
     <Compile Include="src\Helpers\RelayCommand.cs" />
     <Compile Include="src\Models\Chakra.cs" />
     <Compile Include="src\Models\ClientProfile.cs" />
@@ -73,6 +75,7 @@
     <Compile Include="src\ViewModels\ThemeViewModel.cs" />
     <Compile Include="src\ViewModels\ViewModelBase.cs" />
     <Compile Include="src\Views\ChakraSelector.axaml.cs" />
+    <Compile Include="src\Views\ElementSelector.axaml.cs" />
     
     <Compile Include="src\Views\InventoryView.axaml.cs" />
     <Compile Include="src\Views\RitualTimeline.axaml.cs" />

--- a/src/Converters/ElementCheckConverter.cs
+++ b/src/Converters/ElementCheckConverter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using RitualOS.Models;
+
+namespace RitualOS.Converters
+{
+    /// <summary>
+    /// Converter for binding element checkboxes to a collection. 🧰
+    /// </summary>
+    public class ElementCheckConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is List<Element> tags && parameter is Element element)
+            {
+                return tags.Contains(element);
+            }
+            return false;
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool isChecked && parameter is Element element && targetType == typeof(List<Element>))
+            {
+                var list = new List<Element>();
+                if (isChecked)
+                    list.Add(element);
+                return list;
+            }
+            return new List<Element>();
+        }
+    }
+}

--- a/src/Helpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelper.cs
@@ -1,0 +1,22 @@
+using RitualOS.Models;
+
+namespace RitualOS.Helpers
+{
+    /// <summary>
+    /// Provides emoji helpers for ritual elements. 😄
+    /// </summary>
+    public static class ElementHelper
+    {
+        public static string GetEmoji(Element element) => element switch
+        {
+            Element.Air => "🌬️",
+            Element.Water => "💧",
+            Element.Fire => "🔥",
+            Element.Earth => "🌱",
+            Element.Ether => "✨",
+            _ => string.Empty
+        };
+
+        public static string GetDisplayName(Element element) => element.ToString();
+    }
+}

--- a/src/Models/DreamEntry.cs
+++ b/src/Models/DreamEntry.cs
@@ -19,6 +19,10 @@ namespace RitualOS.Models
         public string Description { get; set; }
         public List<string> Symbols { get; set; } = new();
         public List<Chakra> ChakraTags { get; set; } = new();
+        /// <summary>
+        /// Elements associated with this dream entry.
+        /// </summary>
+        public List<Element> ElementTags { get; set; } = new();
         public List<string> Tags { get; set; } = new();
         public string Interpretation { get; set; }
     }

--- a/src/ViewModels/DreamEntryViewModel.cs
+++ b/src/ViewModels/DreamEntryViewModel.cs
@@ -28,6 +28,7 @@ namespace RitualOS.ViewModels
 
         public ObservableCollection<string> Symbols { get; } = new();
         public ObservableCollection<Chakra> ChakraTags { get; } = new();
+        public ObservableCollection<Element> Elements { get; } = new();
 
         public string Message
         {
@@ -45,6 +46,7 @@ namespace RitualOS.ViewModels
         public ICommand SaveCommand { get; }
         public ICommand AddSymbolCommand { get; }
         public ICommand AddChakraCommand { get; }
+        public ICommand AddElementCommand { get; }
 
         public DreamEntryViewModel()
         {
@@ -53,6 +55,7 @@ namespace RitualOS.ViewModels
             SaveCommand = new RelayCommand(_ => Save(), _ => !string.IsNullOrWhiteSpace(Dream.Title));
             AddSymbolCommand = new RelayCommand(_ => Symbols.Add(string.Empty));
             AddChakraCommand = new RelayCommand(param => AddChakra(param as Chakra?));
+            AddElementCommand = new RelayCommand(param => AddElement(param as Element?));
         }
 
         private void Save()
@@ -61,6 +64,7 @@ namespace RitualOS.ViewModels
             {
                 Dream.Symbols = Symbols.ToList();
                 Dream.ChakraTags = ChakraTags.ToList();
+                Dream.ElementTags = Elements.ToList();
                 DreamDataLoader.SaveDreamToJson(Dream, $"dreams/{Dream.Id}.json");
                 Message = $"Dream '{Dream.Title}' saved successfully!";
             }
@@ -75,6 +79,14 @@ namespace RitualOS.ViewModels
             if (chakra.HasValue && !ChakraTags.Contains(chakra.Value))
             {
                 ChakraTags.Add(chakra.Value);
+            }
+        }
+
+        private void AddElement(Element? element)
+        {
+            if (element.HasValue && !Elements.Contains(element.Value))
+            {
+                Elements.Add(element.Value);
             }
         }
     }

--- a/src/Views/DreamEntryView.axaml
+++ b/src/Views/DreamEntryView.axaml
@@ -26,6 +26,7 @@
             <Button Content="Add Symbol" Command="{Binding AddSymbolCommand}"/>
         </StackPanel>
         <views:ChakraSelector />
+        <views:ElementSelector />
         <TextBox Watermark="Interpretation" Text="{Binding Dream.Interpretation, Mode=TwoWay}" AcceptsReturn="True" Height="80"/>
         <TextBox Watermark="Tags" Text="{Binding Dream.Tags, Converter={StaticResource StringListConverter}}" Width="200"/>
         <TextBlock Text="{Binding Message}" Foreground="{Binding Message, Converter={StaticResource MessageColorConverter}}" Margin="10"/>

--- a/src/Views/ElementSelector.axaml
+++ b/src/Views/ElementSelector.axaml
@@ -1,0 +1,20 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:RitualOS.Converters"
+             x:Class="RitualOS.Views.ElementSelector">
+    <UserControl.Resources>
+        <conv:ElementCheckConverter x:Key="ElementCheckConverter" />
+    </UserControl.Resources>
+    <StackPanel Orientation="Horizontal" Spacing="6">
+        <CheckBox Content="🌬️ Air"
+                  IsChecked="{Binding Elements, Converter={StaticResource ElementCheckConverter}, ConverterParameter=Air}"/>
+        <CheckBox Content="💧 Water"
+                  IsChecked="{Binding Elements, Converter={StaticResource ElementCheckConverter}, ConverterParameter=Water}"/>
+        <CheckBox Content="🔥 Fire"
+                  IsChecked="{Binding Elements, Converter={StaticResource ElementCheckConverter}, ConverterParameter=Fire}"/>
+        <CheckBox Content="🌱 Earth"
+                  IsChecked="{Binding Elements, Converter={StaticResource ElementCheckConverter}, ConverterParameter=Earth}"/>
+        <CheckBox Content="✨ Ether"
+                  IsChecked="{Binding Elements, Converter={StaticResource ElementCheckConverter}, ConverterParameter=Ether}"/>
+    </StackPanel>
+</UserControl>

--- a/src/Views/ElementSelector.axaml.cs
+++ b/src/Views/ElementSelector.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RitualOS.Views
+{
+    public partial class ElementSelector : UserControl
+    {
+        public ElementSelector()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Views/Wizards/RitualTemplateBuilder.axaml
+++ b/src/Views/Wizards/RitualTemplateBuilder.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:views="clr-namespace:RitualOS.Views">
     <Grid ColumnDefinitions="2*,*" RowDefinitions="Auto,*" Margin="10">
         <StackPanel Grid.Column="0" Spacing="6" IsEnabled="{Binding CanEdit}">
             <TextBlock Text="Ritual Template" FontSize="18" FontWeight="Bold"/>
@@ -19,8 +20,7 @@
             <Button Content="Add Chakra" Command="{Binding AddChakraCommand}"/>
             
             <TextBlock Text="Elements" FontWeight="Bold" Margin="0,10,0,0"/>
-            <ListBox ItemsSource="{Binding Elements}" Height="80"/>
-            <Button Content="Add Element" Command="{Binding AddElementCommand}"/>
+            <views:ElementSelector />
             
             <TextBlock Text="Steps" FontWeight="Bold" Margin="0,10,0,0"/>
             <ListBox ItemsSource="{Binding Steps}" Height="80"/>


### PR DESCRIPTION
## PR #1 – Add Element Selector
**Date:** 2025-07-16
**Author:** Justin Gargano
**Feature/Component Affected:** ElementSelector, DreamEntry enhancements

---

### 🔧 Actions Taken:
- [x] Added `ElementHelper` and `ElementCheckConverter` for element icons
- [x] Created reusable `ElementSelector` control and integrated with ritual template builder and dream entry view
- [x] Extended `DreamEntry` and its view model to store selected elements
- [x] Updated project file and built successfully with .NET 8

---

### 📜 Intention Behind Changes:
These updates push forward items in `RitualOS_TODO.md` by providing icon-based element selection. Dreams and ritual templates now capture elemental alignment, paving the way for richer filtering and ritual suggestions.

---

### 🧠 Notes for Future You:
More UI polish will be needed to display selected elements within lists. Additional role-based restrictions might also hook into these new features.

---

### 🧪 Testing Summary:
- [x] Built and compiled successfully (yes)
- [ ] Manual UI tested (no UI environment)
- [ ] Edge cases validated (n/a)
- Known issues: none


------
https://chatgpt.com/codex/tasks/task_e_6877ea4168f88332ba731161add46c13