### PR TITLE
Fix wizards namespace and grid spacing

### DIFF
--- a/src/Views/Wizards/ClientProfileDashboard.axaml
+++ b/src/Views/Wizards/ClientProfileDashboard.axaml
@@ -20,7 +20,7 @@
       <Border Classes="card">
         <StackPanel Spacing="10">
           <TextBlock Text="Contact Information" FontSize="18" FontWeight="Medium"/>
-          <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="5">
+          <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
             <TextBlock Text="Email:" Grid.Row="0" Grid.Column="0" FontWeight="Bold"/>
             <TextBlock Text="{Binding Client.Email}" Grid.Row="0" Grid.Column="1" />
             <TextBlock Text="Phone:" Grid.Row="1" Grid.Column="0" FontWeight="Bold"/>

--- a/src/Views/Wizards/ClientProfileDashboard.axaml.cs
+++ b/src/Views/Wizards/ClientProfileDashboard.axaml.cs
@@ -3,7 +3,7 @@ using RitualOS.Models;
 using RitualOS.ViewModels.Wizards;
 using System.Collections.Generic;
 
-namespace RitualOS.Views
+namespace RitualOS.Views.Wizards
 {
     public partial class ClientProfileDashboard : UserControl
     {

--- a/src/Views/Wizards/CodexRewritePreviewer.axaml.cs
+++ b/src/Views/Wizards/CodexRewritePreviewer.axaml.cs
@@ -1,6 +1,6 @@
 using Avalonia.Controls;
 
-namespace RitualOS.Views
+namespace RitualOS.Views.Wizards
 {
     public partial class CodexRewritePreviewer : UserControl
     {


### PR DESCRIPTION
### PR #XXX – Fix wizard namespaces
**Author:** Codex
**Feature/Component Affected:** ClientProfileDashboard, CodexRewritePreviewer

#### 🔧 Actions Taken:
- [x] Fixed namespaces for wizard views
- [x] Removed unsupported spacing properties from dashboard grid

#### 📜 Intention Behind Changes:
Avalonia's code generation failed because the view classes were in the wrong namespace. Aligning the namespaces with the XAML declarations lets the build generate the `InitializeComponent` method correctly. Removing `ColumnSpacing`/`RowSpacing` resolves an AVLN:0004 error.

#### 🧠 Notes for Future You:
These were small fixes to get the project compiling. If spacing between grid items is required, consider margins or a wrapping panel.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual UI testing: N/A
- Edge cases validated: N/A


------
https://chatgpt.com/codex/tasks/task_e_68781e3b00548332abaff74e0bf996c2