### PR TITLE
Fix Avalonia compile tasks

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- Ensure Avalonia build tasks run so InitializeComponent gets generated -->
+    <UseAvalonia>true</UseAvalonia>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### PR # - Ensure Avalonia build tasks run

**Author:** Codex
**Feature/Component Affected:** RitualOS.csproj

#### 🔧 Actions Taken:
- [x] Added `<UseAvalonia>true</UseAvalonia>` property

#### 📜 Intention Behind Changes:
Ensures Avalonia's XAML code-generation runs so `InitializeComponent` is available during compilation.

#### 🧪 Testing Summary:
- [x] `dotnet build RitualOS.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68782606b70483328ca9446d848e6df9