### PR TITLE
Add plugin docs and standard ritual file naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ Thumbs.db
 RitualOS_TODO.md
 temp_list.txt
 allfiles.txt
-logs/
+/logs/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key folders you will find in RitualOS:
 /assets/          -> Images, icons, elemental symbols
 /settings/        -> user preferences
 /plugins/         -> rewrite engine modules
-/logs/            -> Application logs
+/logs/            -> Application logs for debugging and auditing
 /docs/user_guide/ -> User manual and quick-start guide
 ```
 Example ritual files are stored using the pattern `ritual_<timestamp>.json`.

--- a/docs/user_guide/quick_start.md
+++ b/docs/user_guide/quick_start.md
@@ -1,0 +1,2 @@
+# User Guide
+Welcome to RitualOS! This guide covers the basics to get you started.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,2 @@
+# Plugins
+This folder hosts rewrite engine modules.

--- a/src/Services/RitualDataLoader.cs
+++ b/src/Services/RitualDataLoader.cs
@@ -46,11 +46,18 @@ namespace RitualOS.Services
         /// Serializes a <see cref="RitualEntry"/> to the specified path in a pretty printed JSON format.
         /// </summary>
         /// <param name="entry">The ritual entry to save.</param>
-        /// <param name="filePath">File path where the JSON should be written.</param>
+        /// <param name="filePath">File path where the JSON should be written. If null or empty, a file
+        /// name will be generated using the pattern ritual_&lt;timestamp&gt;.json.</param>
         public static void SaveRitualToJson(RitualEntry entry, string filePath)
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
+                    filePath = $"ritual_{timestamp}.json";
+                }
+
                 var json = JsonSerializer.Serialize(entry, new JsonSerializerOptions { WriteIndented = true });
                 File.WriteAllText(filePath, json);
             }


### PR DESCRIPTION
### PR #1 – Add plugin and user guide directories
**Author:** Codex
**Feature/Component Affected:** RitualDataLoader, documentation

#### 🔧 Actions Taken:
- [x] Added docs/user_guide and plugins directories with README placeholders
- [x] Updated .gitignore to ignore /logs/
- [x] Added timestamp-based file naming to `RitualDataLoader.SaveRitualToJson`
- [x] Tweaked README entries for plugin and log directories

#### 📜 Intention Behind Changes:
These updates finish the professional additions noted in `RitualOS_TODO.md`. The app now standardizes ritual JSON names and clarifies how plugins and logs should be organized. A new user guide folder provides a starting point for documentation.

#### 🧠 Notes for Future You:
The logs folder is ignored in Git, so runtime log files won't clutter the repo. Plugin infrastructure can grow under `plugins/` as rewriting rules are implemented.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully with `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687827d725f08332bff396b8f1313020