### PR TITLE
PR #XXX – Remove duplicate AvaloniaResource includes

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -109,33 +109,4 @@
     <Compile Include="src\Views\DreamParserView.axaml.cs" />
   </ItemGroup>
 
-  <!-- Include XAML files for compilation -->
-  <ItemGroup>
-    <AvaloniaResource Include="src\Views\ChakraSelector.axaml" />
-    <AvaloniaResource Include="src\Views\ElementSelector.axaml" />
-    <AvaloniaResource Include="src\Views\InventoryView.axaml" />
-    <AvaloniaResource Include="src\Views\RitualTimeline.axaml" />
-    <AvaloniaResource Include="src\Views\Wizards\ClientProfileDashboard.axaml" />
-    <AvaloniaResource Include="src\Views\Wizards\CodexRewritePreviewer.axaml" />
-    <AvaloniaResource Include="src\Views\Wizards\RitualTemplateBuilder.axaml" />
-    <AvaloniaResource Include="src\Views\MainShellView.axaml" />
-    <AvaloniaResource Include="src\Views\DreamDictionary.axaml" />
-    <AvaloniaResource Include="src\Views\RitualLibrary.axaml" />
-    <AvaloniaResource Include="src\Views\ClientDetailView.axaml" />
-    <AvaloniaResource Include="src\Views\SymbolSearch.axaml" />
-    <AvaloniaResource Include="src\Views\DocumentViewer.axaml" />
-    <AvaloniaResource Include="src\Views\ThemeSwitcher.axaml" />
-    <AvaloniaResource Include="src\Views\ExportView.axaml" />
-    <AvaloniaResource Include="src\Views\AnalyticsView.axaml" />
-    <AvaloniaResource Include="src\Views\DreamParserView.axaml" />
-    
-    <!-- Theme files -->
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Dark.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Light.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Amanda.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Flame.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Parchment.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Magical.xaml" />
-    <AvaloniaResource Include="src\Styles\Themes\Theme.Material.xaml" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
**Author:** Codex
**Feature/Component Affected:** RitualOS.csproj

#### 🔧 Actions Taken:
- [ ] Added new functionality
- [ ] Refactored logic/component
- [x] Fixed bug or regression
- [ ] Updated layout/UX/text/symbol handling/etc.

#### 📜 Intention Behind Changes:
Removing the explicit `<AvaloniaResource>` entries prevents Avalonia from loading the same XAML files twice. This eliminates the `Duplicate x:Class` errors reported during build.

#### 🧠 Notes for Future You:
The project still fails to compile due to missing service interfaces such as `IUserSettingsService` and `IRitualDataLoader`. These need stubs or implementations for a successful build.

#### 🧪 Testing Summary:
- [ ] Built and compiled successfully (no)
- [ ] Manual UI tested
- [ ] Edge cases validated
- Known issues: build fails with missing interface errors (see log).


------
https://chatgpt.com/codex/tasks/task_e_68784983b59c8332923de5ca7982c5cf