### PR TITLE
Integrate dream dictionary lookup

### DIFF
--- a/tests/RitualOS.Tests/DreamParserTests.cs
+++ b/tests/RitualOS.Tests/DreamParserTests.cs
@@ -1,0 +1,18 @@
+using RitualOS.Services;
+using Xunit;
+
+namespace RitualOS.Tests;
+
+public class DreamParserTests
+{
+    [Fact]
+    public async Task AnalyzeDream_ReturnsSymbolMeanings()
+    {
+        var service = new DreamParserService();
+        var analysis = await service.AnalyzeDreamAsync("fire and water");
+        Assert.Contains("fire", analysis.ExtractedSymbols);
+        Assert.Contains("water", analysis.ExtractedSymbols);
+        Assert.True(analysis.SymbolMeanings.ContainsKey("fire"));
+        Assert.True(analysis.SymbolMeanings.ContainsKey("water"));
+    }
+}


### PR DESCRIPTION
### PR #XXX – Integrate dream dictionary lookup
**Author:** Codex
**Feature/Component Affected:** DreamParserService, DreamParserTests

#### 🔧 Actions Taken:
- [x] Added dictionary search paths and lookup logic
- [x] Refactored dream parser to store symbol meanings
- [x] Added unit test for dictionary integration

#### 📜 Intention Behind Changes:
This change enhances dream parsing by linking extracted symbols to entries in the bundled dream dictionary. It unlocks richer analysis output and verifies the feature with a new test.

#### 🧠 Notes for Future You:
Loading paths are resolved relative to the executing directory. Adjust the search list if project layout changes.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- [x] Unit tests all pass


------
https://chatgpt.com/codex/tasks/task_e_6878e0ceb328833291ae28240d6386c8