### PR TITLE
Implement theme picker and new palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Schema references live in the `docs` folder:
 - [Dream Dictionary](docs/DreamDictionary/RitualOS_Dream_Dictionary.md)
 - [Ritual Timeline](docs/ritual_timeline.md)
 - [Plugin System](docs/plugin_system.md)
+- [Custom Theme Guide](docs/custom_theme_guide.md)
+- [Offline Roadmap](docs/offline_roadmap.md)
 
 
 ## Pitch Deck

--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -110,6 +110,7 @@
     <Compile Include="src\Views\SymbolSearch.axaml.cs" />
     <Compile Include="src\Views\DocumentViewer.axaml.cs" />
     <Compile Include="src\Views\ThemeSwitcher.axaml.cs" />
+    <Compile Include="src\Views\ThemePickerWindow.axaml.cs" />
     <Compile Include="src\Views\ExportView.axaml.cs" />
     <Compile Include="src\Views\AnalyticsView.axaml.cs" />
     <Compile Include="src\Views\DreamParserView.axaml.cs" />

--- a/docs/custom_theme_guide.md
+++ b/docs/custom_theme_guide.md
@@ -1,0 +1,10 @@
+# Creating Custom Themes
+
+Want to give RitualOS your own vibe? Follow these steps to craft a new theme:
+
+1. Duplicate any `Theme.*.xaml` file in `src/Styles/Themes/` and rename it, e.g., `Theme.MyStyle.xaml`.
+2. Edit the color brushes inside to match your palette.
+3. Add the new file name to `AvailableThemes` in `ThemeViewModel.cs`.
+4. Rebuild RitualOS and pick your theme from the Theme tab or the Theme Picker window.
+
+That’s it—your colors, your magic! 🌟

--- a/docs/offline_roadmap.md
+++ b/docs/offline_roadmap.md
@@ -1,0 +1,31 @@
+# RitualOS Offline Roadmap
+
+This document outlines short-term goals for RitualOS that do not rely on cloud APIs or mobile platforms. Everything listed here is designed to work fully offline.
+
+## 1. Improved Theme Customization
+- [x] Expand the `themes/` folder with additional color palettes
+- [x] Add a Theme Picker dialog so users can preview themes before applying them
+- [x] Document how to create custom themes in the `docs/` folder
+
+## 2. Enhanced Analytics
+- [ ] Extend `AnalyticsViewModel` to display ritual frequency by moon phase
+- [ ] Include local stats about ingredient usage
+- [ ] Provide export options for CSV and Markdown reports
+
+## 3. Plugin Growth
+- [ ] Build more example plugins in the `plugins/` directory
+- [ ] Outline plugin development in `docs/plugin_system.md`
+- [ ] Encourage community contributions for tarot spreads, astrology tools, and more
+
+## 4. Data Import & Export
+- [ ] Add wizards for importing existing ritual logs
+- [ ] Support exporting all data to a single JSON bundle
+- [ ] Keep operations offline, relying only on file reads and writes
+
+## 5. Community Templates
+- [ ] Offer a curated set of ritual templates in `samples/`
+- [ ] Highlight recent additions in the main dashboard
+- [ ] Allow users to share templates via local files without a server
+
+---
+These milestones will breathe new life into the project while honoring the current offline-first focus. They also pave the way for future online features when infrastructure becomes available.

--- a/src/Styles/Themes/Theme.Forest.xaml
+++ b/src/Styles/Themes/Theme.Forest.xaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="BackgroundBrush" Color="#0e1f0b" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#e0ffe0" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#5e9c76" />
+</ResourceDictionary>

--- a/src/Styles/Themes/Theme.Forest.xaml.cs
+++ b/src/Styles/Themes/Theme.Forest.xaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RitualOS.Styles.Themes
+{
+    public partial class Theme_Forest : ResourceDictionary
+    {
+        public Theme_Forest()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Styles/Themes/Theme.Ocean.xaml
+++ b/src/Styles/Themes/Theme.Ocean.xaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="BackgroundBrush" Color="#001f3f" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#e0f7ff" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#0099cc" />
+</ResourceDictionary>

--- a/src/Styles/Themes/Theme.Ocean.xaml.cs
+++ b/src/Styles/Themes/Theme.Ocean.xaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RitualOS.Styles.Themes
+{
+    public partial class Theme_Ocean : ResourceDictionary
+    {
+        public Theme_Ocean()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/ViewModels/ThemeViewModel.cs
+++ b/src/ViewModels/ThemeViewModel.cs
@@ -21,7 +21,9 @@ namespace RitualOS.ViewModels
             "Theme.Material.xaml",
             "Theme.Magical.xaml",
             "Theme.Parchment.xaml",
-            "Theme.HighContrast.xaml"
+            "Theme.HighContrast.xaml",
+            "Theme.Forest.xaml",
+            "Theme.Ocean.xaml"
         };
 
         public string SelectedTheme

--- a/src/Views/ThemePickerWindow.axaml
+++ b/src/Views/ThemePickerWindow.axaml
@@ -1,0 +1,16 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:RitualOS.ViewModels"
+        x:Class="RitualOS.Views.ThemePickerWindow"
+        Width="400" Height="300" Title="Theme Picker">
+    <Window.DataContext>
+        <vm:ThemeViewModel />
+    </Window.DataContext>
+    <StackPanel Margin="20" Spacing="10">
+        <TextBlock Text="Preview Themes" FontSize="16" HorizontalAlignment="Center"/>
+        <ComboBox ItemsSource="{Binding AvailableThemes}" SelectedItem="{Binding SelectedTheme}" />
+        <Border Background="{DynamicResource BackgroundBrush}" Padding="15" CornerRadius="6">
+            <TextBlock Text="This is a preview" Foreground="{DynamicResource PrimaryTextBrush}"/>
+        </Border>
+    </StackPanel>
+</Window>

--- a/src/Views/ThemePickerWindow.axaml.cs
+++ b/src/Views/ThemePickerWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace RitualOS.Views
+{
+    public partial class ThemePickerWindow : Window
+    {
+        public ThemePickerWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Views/ThemeSwitcher.axaml
+++ b/src/Views/ThemeSwitcher.axaml
@@ -6,6 +6,9 @@
         <vm:ThemeViewModel />
     </UserControl.DataContext>
 
-    <ComboBox ItemsSource="{Binding AvailableThemes}"
-              SelectedItem="{Binding SelectedTheme}" />
+    <StackPanel Spacing="6">
+        <ComboBox ItemsSource="{Binding AvailableThemes}"
+                  SelectedItem="{Binding SelectedTheme}" />
+        <Button Content="Open Theme Picker" Click="OpenPicker_Click" />
+    </StackPanel>
 </UserControl>

--- a/src/Views/ThemeSwitcher.axaml.cs
+++ b/src/Views/ThemeSwitcher.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace RitualOS.Views
 {
@@ -8,5 +9,11 @@ namespace RitualOS.Views
         {
             InitializeComponent();
         }
+
+        private void OpenPicker_Click(object? sender, RoutedEventArgs e)
+        {
+            var picker = new ThemePickerWindow();
+            picker.Show();
+        }
     }
-} 
+}


### PR DESCRIPTION
### PR #XXX – Theme picker and docs
**Author:** Codex
**Feature/Component Affected:** ThemeViewModel, ThemeSwitcher

#### 🔧 Actions Taken:
- [x] Added two new themes (Forest and Ocean)
- [x] Created `ThemePickerWindow` to preview selections
- [x] Updated `ThemeSwitcher` with button to open the picker
- [x] Documented custom theme creation and linked from README
- [x] Checked off completed items in the offline roadmap

#### 📜 Intention Behind Changes:
Bring visual variety to RitualOS and guide users in crafting their own styles while demonstrating progress on the offline roadmap.

#### 🧠 Notes for Future You:
Theme files load automatically; no CS project tweaks needed for them. Keep exploring analytics goals next!

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual UI not tested in this environment
- Edge cases not applicable


------
https://chatgpt.com/codex/tasks/task_e_6879b90efe288332abccf00d6b7475c5