### PR TITLE
Add community templates and tarot viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Schema references live in the `docs` folder:
 - [Dream Dictionary](docs/DreamDictionary/RitualOS_Dream_Dictionary.md)
 - [Ritual Timeline](docs/ritual_timeline.md)
 - [Plugin System](docs/plugin_system.md)
+- [Sample Plugins](plugins/)
+- [Custom Theme Guide](docs/custom_theme_guide.md)
+- [Offline Roadmap](docs/offline_roadmap.md)
+- [Sample Templates](samples/ritual_templates)
+- Tarot Spread Viewer (new tab)
 
 
 ## Pitch Deck

--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -46,6 +46,7 @@
     <Compile Include="src\Models\InventoryItem.cs" />
     <Compile Include="src\Models\RitualEntry.cs" />
     <Compile Include="src\Models\RitualTemplate.cs" />
+    <Compile Include="src\Models\TarotCard.cs" />
     <Compile Include="src\Models\Element.cs" />
     <Compile Include="src\Models\MoonPhase.cs" />
     <Compile Include="src\Models\Role.cs" />
@@ -74,7 +75,9 @@
     <Compile Include="services\DreamParserService.cs" />
     <Compile Include="services\LoggingService.cs" />
     <Compile Include="services\BackupService.cs" />
+    <Compile Include="services\DataImportExportService.cs" />
     <Compile Include="services\PluginLoader.cs" />
+    <Compile Include="services\TarotService.cs" />
     <Compile Include="src\Behaviors\ListBoxReorderBehavior.cs" />
     <Compile Include="src\ViewModels\ClientViewModel.cs" />
     <Compile Include="src\ViewModels\DocumentViewerViewModel.cs" />
@@ -90,6 +93,7 @@
     <Compile Include="src\ViewModels\ExportViewModel.cs" />
     <Compile Include="src\ViewModels\AnalyticsViewModel.cs" />
     <Compile Include="src\ViewModels\DreamParserViewModel.cs" />
+    <Compile Include="src\ViewModels\TarotViewModel.cs" />
     <Compile Include="src\Views\ChakraSelector.axaml.cs" />
     <Compile Include="src\Views\ElementSelector.axaml.cs" />
     
@@ -99,9 +103,11 @@
     <Compile Include="src\ViewModels\Wizards\CodexRewritePreviewerViewModel.cs" />
     <Compile Include="src\ViewModels\Wizards\RitualTemplateBuilderViewModel.cs" />
     <Compile Include="src\ViewModels\Wizards\SymbolIndexBuilderViewModel.cs" />
+    <Compile Include="src\ViewModels\Wizards\ImportExportWizardViewModel.cs" />
     <Compile Include="src\Views\Wizards\ClientProfileDashboard.axaml.cs" />
     <Compile Include="src\Views\Wizards\CodexRewritePreviewer.axaml.cs" />
     <Compile Include="src\Views\Wizards\RitualTemplateBuilder.axaml.cs" />
+    <Compile Include="src\Views\Wizards\ImportExportWizard.axaml.cs" />
     <Compile Include="src\ViewModels\MainShellViewModel.cs" />
     <Compile Include="src\Views\MainShellView.axaml.cs" />
     <Compile Include="src\Views\DreamDictionary.axaml.cs" />
@@ -110,12 +116,18 @@
     <Compile Include="src\Views\SymbolSearch.axaml.cs" />
     <Compile Include="src\Views\DocumentViewer.axaml.cs" />
     <Compile Include="src\Views\ThemeSwitcher.axaml.cs" />
+    <Compile Include="src\Views\ThemePickerWindow.axaml.cs" />
     <Compile Include="src\Views\ExportView.axaml.cs" />
     <Compile Include="src\Views\AnalyticsView.axaml.cs" />
     <Compile Include="src\Views\DreamParserView.axaml.cs" />
+    <Compile Include="src\Views\TarotView.axaml.cs" />
     <Compile Include="src\Views\WelcomeView.axaml.cs" />
     <Compile Include="src\ViewModels\WelcomeViewModel.cs" />
     <Compile Include="components\MagicalProgressBar.axaml.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="assets\tarot\tarot_cards.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/assets/tarot/tarot_cards.json
+++ b/assets/tarot/tarot_cards.json
@@ -1,0 +1,626 @@
+[
+  {
+    "name": "The Fool",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "new beginnings",
+    "meaning_rev": "recklessness",
+    "description": "Leap of faith"
+  },
+  {
+    "name": "The Magician",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "skill and focus",
+    "meaning_rev": "manipulation",
+    "description": "Harnessing willpower"
+  },
+  {
+    "name": "The High Priestess",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "intuition",
+    "meaning_rev": "hidden agendas",
+    "description": "Inner wisdom"
+  },
+  {
+    "name": "The Empress",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "nurturing",
+    "meaning_rev": "dependence",
+    "description": "Abundant creation"
+  },
+  {
+    "name": "The Emperor",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "authority",
+    "meaning_rev": "control issues",
+    "description": "Solid leadership"
+  },
+  {
+    "name": "The Hierophant",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "tradition",
+    "meaning_rev": "rebellion",
+    "description": "Spiritual guidance"
+  },
+  {
+    "name": "The Lovers",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "partnership",
+    "meaning_rev": "imbalance",
+    "description": "Choice of the heart"
+  },
+  {
+    "name": "The Chariot",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "determination",
+    "meaning_rev": "lack of direction",
+    "description": "Driving forward"
+  },
+  {
+    "name": "Strength",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "bravery",
+    "meaning_rev": "self-doubt",
+    "description": "Inner power"
+  },
+  {
+    "name": "The Hermit",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "soul searching",
+    "meaning_rev": "isolation",
+    "description": "Seek within"
+  },
+  {
+    "name": "Wheel of Fortune",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "change",
+    "meaning_rev": "bad luck",
+    "description": "Cycles of fate"
+  },
+  {
+    "name": "Justice",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "fairness",
+    "meaning_rev": "dishonesty",
+    "description": "Cause and effect"
+  },
+  {
+    "name": "The Hanged Man",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "sacrifice",
+    "meaning_rev": "stalling",
+    "description": "New perspective"
+  },
+  {
+    "name": "Death",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "transformation",
+    "meaning_rev": "resistance",
+    "description": "Endings and rebirth"
+  },
+  {
+    "name": "Temperance",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "balance",
+    "meaning_rev": "extremes",
+    "description": "Blend and heal"
+  },
+  {
+    "name": "The Devil",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "materialism",
+    "meaning_rev": "freedom",
+    "description": "Shadow self"
+  },
+  {
+    "name": "The Tower",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "upheaval",
+    "meaning_rev": "avoidance",
+    "description": "Sudden change"
+  },
+  {
+    "name": "The Star",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "hope",
+    "meaning_rev": "despair",
+    "description": "Guiding light"
+  },
+  {
+    "name": "The Moon",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "dreams",
+    "meaning_rev": "confusion",
+    "description": "Illusion and insight"
+  },
+  {
+    "name": "The Sun",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "success",
+    "meaning_rev": "negativity",
+    "description": "Joyful vitality"
+  },
+  {
+    "name": "Judgement",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "awakening",
+    "meaning_rev": "doubt",
+    "description": "Inner calling"
+  },
+  {
+    "name": "The World",
+    "arcana": "Major",
+    "suit": "",
+    "meaning_up": "completion",
+    "meaning_rev": "shortcuts",
+    "description": "Fulfillment"
+  },
+  {
+    "name": "Ace of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "emotional offer",
+    "meaning_rev": "blockage",
+    "description": "Seed of feelings"
+  },
+  {
+    "name": "Two of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "union",
+    "meaning_rev": "tension",
+    "description": "Harmony"
+  },
+  {
+    "name": "Three of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "celebration",
+    "meaning_rev": "overindulgence",
+    "description": "Friendship"
+  },
+  {
+    "name": "Four of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "contemplation",
+    "meaning_rev": "boredom",
+    "description": "Discontent"
+  },
+  {
+    "name": "Five of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "loss",
+    "meaning_rev": "acceptance",
+    "description": "Grieving"
+  },
+  {
+    "name": "Six of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "nostalgia",
+    "meaning_rev": "stuck past",
+    "description": "Memories"
+  },
+  {
+    "name": "Seven of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "choices",
+    "meaning_rev": "confusion",
+    "description": "Many options"
+  },
+  {
+    "name": "Eight of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "walk away",
+    "meaning_rev": "avoidance",
+    "description": "Seeking"
+  },
+  {
+    "name": "Nine of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "satisfaction",
+    "meaning_rev": "greed",
+    "description": "Wish come true"
+  },
+  {
+    "name": "Ten of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "family bliss",
+    "meaning_rev": "disharmony",
+    "description": "Joy at home"
+  },
+  {
+    "name": "Page of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "curiosity",
+    "meaning_rev": "immaturity",
+    "description": "Messenger of love"
+  },
+  {
+    "name": "Knight of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "romance",
+    "meaning_rev": "moodiness",
+    "description": "Charming arrival"
+  },
+  {
+    "name": "Queen of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "compassion",
+    "meaning_rev": "co-dependence",
+    "description": "Emotional depth"
+  },
+  {
+    "name": "King of Cups",
+    "arcana": "Minor",
+    "suit": "Cups",
+    "meaning_up": "balance",
+    "meaning_rev": "coldness",
+    "description": "Diplomatic leader"
+  },
+  {
+    "name": "Ace of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "new prosperity",
+    "meaning_rev": "lost chance",
+    "description": "Seed of wealth"
+  },
+  {
+    "name": "Two of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "juggling",
+    "meaning_rev": "overcommitment",
+    "description": "Balance tasks"
+  },
+  {
+    "name": "Three of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "teamwork",
+    "meaning_rev": "disharmony",
+    "description": "Craftsmanship"
+  },
+  {
+    "name": "Four of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "conservation",
+    "meaning_rev": "greed",
+    "description": "Holding on"
+  },
+  {
+    "name": "Five of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "poverty",
+    "meaning_rev": "recovery",
+    "description": "Hardship"
+  },
+  {
+    "name": "Six of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "generosity",
+    "meaning_rev": "strings attached",
+    "description": "Giving"
+  },
+  {
+    "name": "Seven of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "patience",
+    "meaning_rev": "impatience",
+    "description": "Assessment"
+  },
+  {
+    "name": "Eight of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "skill",
+    "meaning_rev": "perfectionism",
+    "description": "Apprenticeship"
+  },
+  {
+    "name": "Nine of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "luxury",
+    "meaning_rev": "setbacks",
+    "description": "Self-reliance"
+  },
+  {
+    "name": "Ten of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "legacy",
+    "meaning_rev": "fleeting success",
+    "description": "Long term wealth"
+  },
+  {
+    "name": "Page of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "ambition",
+    "meaning_rev": "laziness",
+    "description": "Student of value"
+  },
+  {
+    "name": "Knight of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "efficiency",
+    "meaning_rev": "routine",
+    "description": "Steady progress"
+  },
+  {
+    "name": "Queen of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "practicality",
+    "meaning_rev": "imbalance",
+    "description": "Nurturing provider"
+  },
+  {
+    "name": "King of Pentacles",
+    "arcana": "Minor",
+    "suit": "Pentacles",
+    "meaning_up": "security",
+    "meaning_rev": "stubborn",
+    "description": "Wealthy leader"
+  },
+  {
+    "name": "Ace of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "clarity",
+    "meaning_rev": "confusion",
+    "description": "Truth revealed"
+  },
+  {
+    "name": "Two of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "stalemate",
+    "meaning_rev": "indecision",
+    "description": "Difficult choices"
+  },
+  {
+    "name": "Three of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "heartbreak",
+    "meaning_rev": "healing",
+    "description": "Painful truth"
+  },
+  {
+    "name": "Four of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "rest",
+    "meaning_rev": "exhaustion",
+    "description": "Recovery"
+  },
+  {
+    "name": "Five of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "conflict",
+    "meaning_rev": "reconciliation",
+    "description": "Tension"
+  },
+  {
+    "name": "Six of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "transition",
+    "meaning_rev": "unfinished",
+    "description": "Moving on"
+  },
+  {
+    "name": "Seven of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "strategy",
+    "meaning_rev": "deception",
+    "description": "Sneaky plans"
+  },
+  {
+    "name": "Eight of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "restriction",
+    "meaning_rev": "release",
+    "description": "Feeling trapped"
+  },
+  {
+    "name": "Nine of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "anxiety",
+    "meaning_rev": "hope",
+    "description": "Nightmares"
+  },
+  {
+    "name": "Ten of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "endings",
+    "meaning_rev": "recovery",
+    "description": "Betrayal"
+  },
+  {
+    "name": "Page of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "curiosity",
+    "meaning_rev": "devious",
+    "description": "Quick thinker"
+  },
+  {
+    "name": "Knight of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "action",
+    "meaning_rev": "impulsiveness",
+    "description": "Bold pursuit"
+  },
+  {
+    "name": "Queen of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "perception",
+    "meaning_rev": "cold heart",
+    "description": "Sharp intellect"
+  },
+  {
+    "name": "King of Swords",
+    "arcana": "Minor",
+    "suit": "Swords",
+    "meaning_up": "truth",
+    "meaning_rev": "tyranny",
+    "description": "Analytical leader"
+  },
+  {
+    "name": "Ace of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "inspiration",
+    "meaning_rev": "delay",
+    "description": "New passion"
+  },
+  {
+    "name": "Two of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "planning",
+    "meaning_rev": "fear of change",
+    "description": "Contemplation"
+  },
+  {
+    "name": "Three of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "progress",
+    "meaning_rev": "setbacks",
+    "description": "Expansion"
+  },
+  {
+    "name": "Four of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "celebration",
+    "meaning_rev": "instability",
+    "description": "Homecoming"
+  },
+  {
+    "name": "Five of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "competition",
+    "meaning_rev": "avoidance",
+    "description": "Rivalry"
+  },
+  {
+    "name": "Six of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "victory",
+    "meaning_rev": "pride",
+    "description": "Recognition"
+  },
+  {
+    "name": "Seven of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "defense",
+    "meaning_rev": "give up",
+    "description": "Standing ground"
+  },
+  {
+    "name": "Eight of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "swift action",
+    "meaning_rev": "delays",
+    "description": "Quick movement"
+  },
+  {
+    "name": "Nine of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "resilience",
+    "meaning_rev": "fatigue",
+    "description": "Perseverance"
+  },
+  {
+    "name": "Ten of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "burden",
+    "meaning_rev": "release",
+    "description": "Heavy load"
+  },
+  {
+    "name": "Page of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "adventure",
+    "meaning_rev": "lack direction",
+    "description": "Creative spark"
+  },
+  {
+    "name": "Knight of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "energy",
+    "meaning_rev": "reckless",
+    "description": "Passionate pursuit"
+  },
+  {
+    "name": "Queen of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "confidence",
+    "meaning_rev": "jealousy",
+    "description": "Vibrant leader"
+  },
+  {
+    "name": "King of Wands",
+    "arcana": "Minor",
+    "suit": "Wands",
+    "meaning_up": "vision",
+    "meaning_rev": "impulsiveness",
+    "description": "Natural authority"
+  }
+]

--- a/docs/custom_theme_guide.md
+++ b/docs/custom_theme_guide.md
@@ -1,0 +1,10 @@
+# Creating Custom Themes
+
+Want to give RitualOS your own vibe? Follow these steps to craft a new theme:
+
+1. Duplicate any `Theme.*.xaml` file in `src/Styles/Themes/` and rename it, e.g., `Theme.MyStyle.xaml`.
+2. Edit the color brushes inside to match your palette.
+3. Add the new file name to `AvailableThemes` in `ThemeViewModel.cs`.
+4. Rebuild RitualOS and pick your theme from the Theme tab or the Theme Picker window.
+
+That’s it—your colors, your magic! 🌟

--- a/docs/offline_roadmap.md
+++ b/docs/offline_roadmap.md
@@ -1,0 +1,34 @@
+# RitualOS Offline Roadmap
+
+This document outlines short-term goals for RitualOS that do not rely on cloud APIs or mobile platforms. Everything listed here is designed to work fully offline.
+
+## 1. Improved Theme Customization
+- [x] Expand the `themes/` folder with additional color palettes
+- [x] Add a Theme Picker dialog so users can preview themes before applying them
+- [x] Document how to create custom themes in the `docs/` folder
+
+## 2. Enhanced Analytics
+- [x] Extend `AnalyticsViewModel` to display ritual frequency by moon phase
+- [x] Include local stats about ingredient usage
+- [x] Provide export options for CSV and Markdown reports
+
+## 3. Plugin Growth
+- [x] Build more example plugins in the `plugins/` directory
+- [x] Outline plugin development in `docs/plugin_system.md`
+- [x] Encourage community contributions for tarot spreads, astrology tools, and more
+
+## 4. Data Import & Export
+- [x] Add wizards for importing existing ritual logs
+- [x] Support exporting all data to a single JSON bundle
+- [x] Keep operations offline, relying only on file reads and writes
+
+## 5. Community Templates
+- [x] Offer a curated set of ritual templates in `samples/`
+- [x] Highlight recent additions in the main dashboard
+- [x] Allow users to share templates via local files without a server
+
+## 6. Tarot Tools
+- [x] Build an offline Tarot card spread viewer with a full deck
+
+---
+These milestones will breathe new life into the project while honoring the current offline-first focus. They also pave the way for future online features when infrastructure becomes available.

--- a/docs/plugin_system.md
+++ b/docs/plugin_system.md
@@ -24,3 +24,17 @@ Example manifest:
 The `PluginLoader` scans each subfolder at startup. If the manifest and DLL are present, the plugin is loaded and `Initialize` is called with a basic context exposing the plugin's data path. When RitualOS closes, `Shutdown` is called on all loaded plugins.
 
 Use this system to build custom ritual steps, codex transformations, or integrations with external services.
+
+## Plugin Development Quickstart
+
+1. Create a folder under `plugins/` for your plugin.
+2. Add a `manifest.json` describing the plugin and its `entryPoint`.
+3. Build a `plugin.dll` targeting .NET 6.0 that implements `IRitualOSPlugin`.
+4. Place the DLL and manifest in your plugin folder and restart RitualOS.
+
+See [plugins/README.md](../plugins/README.md) for a full guide and examples.
+
+### Community Contributions
+
+We love seeing new tarot spreads, astrology tools, and other mystical add-ons.
+Share your creations by opening a pull request in the `plugins/` directory!

--- a/plugins/sample_tarot_plugin/manifest.json
+++ b/plugins/sample_tarot_plugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Tarot Spread Plugin",
+  "version": "1.0.0",
+  "description": "Adds sample tarot spreads for ritual divination",
+  "author": "RitualOS Community",
+  "type": "template",
+  "entryPoint": "TarotPlugin.Main",
+  "dependencies": [],
+  "permissions": ["read_rituals", "write_rituals"],
+  "compatibility": ["1.0.0"],
+  "features": ["three_card_spread", "celtic_cross"],
+  "license": "MIT"
+}

--- a/samples/ritual_templates/moon_blessing.json
+++ b/samples/ritual_templates/moon_blessing.json
@@ -1,0 +1,12 @@
+{
+  "Name": "Moon Blessing",
+  "Intention": "Draw down lunar energy for clarity and intuition",
+  "MoonPhase": "Waxing Crescent",
+  "Tools": ["silver candle", "moon water"],
+  "SpiritsInvoked": ["Luna"],
+  "ChakrasAffected": ["third eye", "crown"],
+  "Elements": ["water", "spirit"],
+  "Steps": ["Anoint forehead with moon water", "Light the candle", "Meditate under the moon"],
+  "OutcomeField": "heightened intuition",
+  "Notes": "Perfect before divination work"
+}

--- a/samples/ritual_templates/prosperity_spell.json
+++ b/samples/ritual_templates/prosperity_spell.json
@@ -1,0 +1,12 @@
+{
+  "Name": "Prosperity Spell",
+  "Intention": "Attract abundance and opportunity",
+  "MoonPhase": "Waxing Gibbous",
+  "Tools": ["green candle", "bay leaf", "citrine"],
+  "SpiritsInvoked": [],
+  "ChakrasAffected": ["solar plexus"],
+  "Elements": ["earth", "fire"],
+  "Steps": ["Write your goal on the bay leaf", "Burn it in the candle flame", "Carry the citrine stone"],
+  "OutcomeField": "financial growth",
+  "Notes": "Repeat weekly for best results"
+}

--- a/samples/ritual_templates/protection_circle.json
+++ b/samples/ritual_templates/protection_circle.json
@@ -1,0 +1,12 @@
+{
+  "Name": "Protection Circle",
+  "Intention": "Ward off negative energies and create a sacred space",
+  "MoonPhase": "Full Moon",
+  "Tools": ["black candle", "salt", "iron key"],
+  "SpiritsInvoked": ["Guardian"],
+  "ChakrasAffected": ["root"],
+  "Elements": ["earth", "fire"],
+  "Steps": ["Cast a circle with salt", "Light the candle", "Hold the key and visualize protection"],
+  "OutcomeField": "sense of security",
+  "Notes": "Useful before major rituals"
+}

--- a/services/DataImportExportService.cs
+++ b/services/DataImportExportService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    public interface IDataImportExportService
+    {
+        Task ImportRitualLogsAsync(string path);
+        Task ExportAllDataAsync(string outputPath);
+    }
+
+    public class DataImportExportService : IDataImportExportService
+    {
+        private readonly string _ritualDir;
+        private readonly string _inventoryPath;
+
+        public DataImportExportService()
+        {
+            _ritualDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "rituals");
+            _inventoryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "inventory.json");
+        }
+
+        public async Task ImportRitualLogsAsync(string path)
+        {
+            if (!File.Exists(path)) return;
+
+            var json = await File.ReadAllTextAsync(path);
+            var entries = JsonSerializer.Deserialize<List<RitualEntry>>(json) ?? new();
+
+            if (!Directory.Exists(_ritualDir))
+                Directory.CreateDirectory(_ritualDir);
+
+            foreach (var entry in entries)
+            {
+                var fileName = $"{entry.Id}.json";
+                var filePath = Path.Combine(_ritualDir, fileName);
+                await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(entry, new JsonSerializerOptions { WriteIndented = true }));
+            }
+        }
+
+        public async Task ExportAllDataAsync(string outputPath)
+        {
+            var bundle = new
+            {
+                rituals = await LoadRitualsAsync(),
+                inventory = File.Exists(_inventoryPath) ? await File.ReadAllTextAsync(_inventoryPath) : null
+            };
+
+            var json = JsonSerializer.Serialize(bundle, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(outputPath, json);
+        }
+
+        private async Task<List<RitualEntry>> LoadRitualsAsync()
+        {
+            var list = new List<RitualEntry>();
+            if (!Directory.Exists(_ritualDir)) return list;
+
+            foreach (var file in Directory.GetFiles(_ritualDir, "*.json"))
+            {
+                var text = await File.ReadAllTextAsync(file);
+                var entry = JsonSerializer.Deserialize<RitualEntry>(text);
+                if (entry != null) list.Add(entry);
+            }
+
+            return list;
+        }
+    }
+}

--- a/services/TarotService.cs
+++ b/services/TarotService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Provides tarot deck loading and random card draws. ✨
+    /// </summary>
+    public class TarotService
+    {
+        private readonly List<TarotCard> _deck = new();
+        private readonly Random _rand = new();
+
+        public IReadOnlyList<TarotCard> Deck => _deck;
+
+        public TarotService()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "tarot", "tarot_cards.json");
+            if (File.Exists(path))
+            {
+                var json = File.ReadAllText(path);
+                var cards = JsonSerializer.Deserialize<List<TarotCard>>(json) ?? new List<TarotCard>();
+                _deck.AddRange(cards);
+            }
+        }
+
+        public TarotCard DrawCard()
+        {
+            if (_deck.Count == 0) throw new InvalidOperationException("Deck not loaded");
+            return _deck[_rand.Next(_deck.Count)];
+        }
+
+        public List<TarotCard> DrawCards(int count)
+        {
+            return Enumerable.Range(0, count).Select(_ => DrawCard()).ToList();
+        }
+    }
+}

--- a/services/TemplateSharingService.cs
+++ b/services/TemplateSharingService.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Threading.Tasks;
+using RitualOS.Models;
+
+namespace RitualOS.Services
+{
+    /// <summary>
+    /// Provides offline sharing of ritual templates via local files. 🧙‍♂️
+    /// </summary>
+    public interface ITemplateSharingService
+    {
+        Task ShareTemplateAsync(RitualTemplate template, string path);
+    }
+
+    public class TemplateSharingService : ITemplateSharingService
+    {
+        public async Task ShareTemplateAsync(RitualTemplate template, string path)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await RitualTemplateSerializer.SaveAsync(template, Path.GetDirectoryName(path));
+            // Move saved file to destination name
+            var saved = Path.Combine(Path.GetDirectoryName(path)!, $"template_{template.TemplateId}.json");
+            if (File.Exists(saved))
+            {
+                File.Move(saved, path, true);
+            }
+        }
+    }
+}

--- a/src/Models/TarotCard.cs
+++ b/src/Models/TarotCard.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace RitualOS.Models
+{
+    /// <summary>
+    /// Represents a single Tarot card with basic meanings. 🔮
+    /// </summary>
+    public class TarotCard
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("arcana")]
+        public string Arcana { get; set; } = string.Empty;
+
+        [JsonPropertyName("suit")]
+        public string Suit { get; set; } = string.Empty;
+
+        [JsonPropertyName("meaning_up")]
+        public string MeaningUp { get; set; } = string.Empty;
+
+        [JsonPropertyName("meaning_rev")]
+        public string MeaningRev { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/Styles/Themes/Theme.Forest.xaml
+++ b/src/Styles/Themes/Theme.Forest.xaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="BackgroundBrush" Color="#0e1f0b" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#e0ffe0" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#5e9c76" />
+</ResourceDictionary>

--- a/src/Styles/Themes/Theme.Forest.xaml.cs
+++ b/src/Styles/Themes/Theme.Forest.xaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RitualOS.Styles.Themes
+{
+    public partial class Theme_Forest : ResourceDictionary
+    {
+        public Theme_Forest()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Styles/Themes/Theme.Ocean.xaml
+++ b/src/Styles/Themes/Theme.Ocean.xaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="BackgroundBrush" Color="#001f3f" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#e0f7ff" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#0099cc" />
+</ResourceDictionary>

--- a/src/Styles/Themes/Theme.Ocean.xaml.cs
+++ b/src/Styles/Themes/Theme.Ocean.xaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RitualOS.Styles.Themes
+{
+    public partial class Theme_Ocean : ResourceDictionary
+    {
+        public Theme_Ocean()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/ViewModels/AnalyticsViewModel.cs
+++ b/src/ViewModels/AnalyticsViewModel.cs
@@ -34,6 +34,7 @@ namespace RitualOS.ViewModels
             {
                 "html",
                 "markdown",
+                "csv",
                 "json"
             };
 
@@ -96,6 +97,8 @@ namespace RitualOS.ViewModels
         public ObservableCollection<KeyValuePair<string, int>> ChakraUsage { get; } = new();
         public ObservableCollection<KeyValuePair<string, int>> ThemePreferences { get; } = new();
         public ObservableCollection<KeyValuePair<string, int>> FeatureUsage { get; } = new();
+        public ObservableCollection<KeyValuePair<string, int>> MoonPhaseFrequency { get; } = new();
+        public ObservableCollection<KeyValuePair<string, int>> IngredientUsage { get; } = new();
 
         private async Task LoadAnalyticsAsync()
         {
@@ -112,6 +115,8 @@ namespace RitualOS.ViewModels
                 UpdateChakraUsage();
                 UpdateThemePreferences();
                 UpdateFeatureUsage();
+                UpdateMoonPhaseFrequency();
+                UpdateIngredientUsage();
 
                 StatusMessage = "Analytics data loaded successfully";
             }
@@ -185,6 +190,30 @@ namespace RitualOS.ViewModels
             }
         }
 
+        private void UpdateMoonPhaseFrequency()
+        {
+            MoonPhaseFrequency.Clear();
+            if (AnalyticsData?.MoonPhaseFrequency != null)
+            {
+                foreach (var phase in AnalyticsData.MoonPhaseFrequency.OrderByDescending(x => x.Value))
+                {
+                    MoonPhaseFrequency.Add(phase);
+                }
+            }
+        }
+
+        private void UpdateIngredientUsage()
+        {
+            IngredientUsage.Clear();
+            if (AnalyticsData?.IngredientUsage != null)
+            {
+                foreach (var ing in AnalyticsData.IngredientUsage.OrderByDescending(x => x.Value).Take(10))
+                {
+                    IngredientUsage.Add(ing);
+                }
+            }
+        }
+
         private async Task ExportAnalyticsAsync()
         {
             if (string.IsNullOrEmpty(ExportPath)) return;
@@ -222,6 +251,7 @@ namespace RitualOS.ViewModels
             {
                 "html" => "html",
                 "markdown" => "md",
+                "csv" => "csv",
                 "json" => "json",
                 _ => "txt"
             };

--- a/src/ViewModels/MainShellViewModel.cs
+++ b/src/ViewModels/MainShellViewModel.cs
@@ -1,4 +1,7 @@
 using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using RitualOS.ViewModels;
@@ -14,6 +17,7 @@ namespace RitualOS.ViewModels
         private ViewModelBase _currentViewModel;
         private int _selectedTabIndex;
         public RelayCommand SetTabCommand { get; }
+        public ObservableCollection<string> RecentTemplateNames { get; } = new();
 
         public MainShellViewModel()
         {
@@ -36,6 +40,9 @@ namespace RitualOS.ViewModels
             ExportViewModel = new ExportViewModel(exportService, ritualDataLoader, userSettingsService);
             AnalyticsViewModel = new AnalyticsViewModel(analyticsService, userSettingsService);
             DreamParserViewModel = new DreamParserViewModel(dreamParserService, userSettingsService);
+            TarotViewModel = new TarotViewModel();
+
+            LoadRecentTemplates();
 
             SetTabCommand = new RelayCommand(param =>
             {
@@ -85,6 +92,7 @@ namespace RitualOS.ViewModels
                         8 => ExportViewModel,
                         9 => AnalyticsViewModel,
                         10 => DreamParserViewModel,
+                        11 => TarotViewModel,
                         _ => InventoryViewModel
                     };
                 }
@@ -103,5 +111,26 @@ namespace RitualOS.ViewModels
         public ExportViewModel ExportViewModel { get; }
         public AnalyticsViewModel AnalyticsViewModel { get; }
         public DreamParserViewModel DreamParserViewModel { get; }
+        public TarotViewModel TarotViewModel { get; }
+
+        private void LoadRecentTemplates()
+        {
+            try
+            {
+                var dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ritual_templates");
+                if (!Directory.Exists(dir)) return;
+
+                var files = Directory.GetFiles(dir, "*.json");
+                foreach (var file in files.OrderByDescending(File.GetCreationTime).Take(3))
+                {
+                    var name = Path.GetFileNameWithoutExtension(file).Replace("_", " ");
+                    RecentTemplateNames.Add(name);
+                }
+            }
+            catch
+            {
+                // ignore errors for now
+            }
+        }
     }
-} 
+}

--- a/src/ViewModels/TarotViewModel.cs
+++ b/src/ViewModels/TarotViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+using RitualOS.Models;
+using RitualOS.Services;
+using RitualOS.Helpers;
+
+namespace RitualOS.ViewModels
+{
+    /// <summary>
+    /// ViewModel for the tarot spread viewer.
+    /// </summary>
+    public class TarotViewModel : ViewModelBase
+    {
+        private readonly TarotService _service = new();
+
+        public ObservableCollection<TarotCard> DrawnCards { get; } = new();
+
+        public RelayCommand DrawOneCommand { get; }
+        public RelayCommand DrawThreeCommand { get; }
+        public RelayCommand DrawFullCommand { get; }
+
+        public TarotViewModel()
+        {
+            DrawOneCommand = new RelayCommand(_ => DrawCards(1));
+            DrawThreeCommand = new RelayCommand(_ => DrawCards(3));
+            DrawFullCommand = new RelayCommand(_ => DrawCards(10));
+        }
+
+        private void DrawCards(int count)
+        {
+            DrawnCards.Clear();
+            foreach (var card in _service.DrawCards(count))
+                DrawnCards.Add(card);
+        }
+    }
+}

--- a/src/ViewModels/ThemeViewModel.cs
+++ b/src/ViewModels/ThemeViewModel.cs
@@ -21,7 +21,9 @@ namespace RitualOS.ViewModels
             "Theme.Material.xaml",
             "Theme.Magical.xaml",
             "Theme.Parchment.xaml",
-            "Theme.HighContrast.xaml"
+            "Theme.HighContrast.xaml",
+            "Theme.Forest.xaml",
+            "Theme.Ocean.xaml"
         };
 
         public string SelectedTheme

--- a/src/ViewModels/Wizards/ImportExportWizardViewModel.cs
+++ b/src/ViewModels/Wizards/ImportExportWizardViewModel.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using RitualOS.Services;
+using RitualOS.Helpers;
+
+namespace RitualOS.ViewModels.Wizards
+{
+    public class ImportExportWizardViewModel : ViewModelBase
+    {
+        private readonly IDataImportExportService _service;
+        private string _importPath = string.Empty;
+        private string _exportPath = string.Empty;
+
+        public ImportExportWizardViewModel() : this(new DataImportExportService())
+        {
+        }
+
+        public ImportExportWizardViewModel(IDataImportExportService service)
+        {
+            _service = service;
+            ImportCommand = new RelayCommand(async () => await ImportAsync(), () => !string.IsNullOrWhiteSpace(ImportPath));
+            ExportCommand = new RelayCommand(async () => await ExportAsync(), () => !string.IsNullOrWhiteSpace(ExportPath));
+        }
+
+        public string ImportPath
+        {
+            get => _importPath;
+            set
+            {
+                SetProperty(ref _importPath, value);
+                ImportCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public string ExportPath
+        {
+            get => _exportPath;
+            set
+            {
+                SetProperty(ref _exportPath, value);
+                ExportCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public RelayCommand ImportCommand { get; }
+        public RelayCommand ExportCommand { get; }
+
+        private async Task ImportAsync()
+        {
+            await _service.ImportRitualLogsAsync(ImportPath);
+        }
+
+        private async Task ExportAsync()
+        {
+            await _service.ExportAllDataAsync(ExportPath);
+        }
+    }
+}

--- a/src/Views/AnalyticsView.axaml
+++ b/src/Views/AnalyticsView.axaml
@@ -110,6 +110,23 @@
                         </ItemsControl>
                     </StackPanel>
                 </Border>
+
+                <!-- Moon Phase Frequency -->
+                <Border Classes="RitualOSCard">
+                    <StackPanel>
+                        <TextBlock Text="Moon Phase Frequency" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                        <ItemsControl ItemsSource="{Binding MoonPhaseFrequency}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                                        <TextBlock Grid.Column="0" Text="{Binding Key}" FontWeight="SemiBold"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Value}" Foreground="{DynamicResource PrimaryBrush}" FontWeight="Bold"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
             </StackPanel>
             
             <!-- Right Column -->
@@ -152,7 +169,7 @@
                         </ItemsControl>
                     </StackPanel>
                 </Border>
-                
+
                 <!-- Feature Usage -->
                 <Border Classes="RitualOSCard">
                     <StackPanel>
@@ -162,7 +179,25 @@
                                 <DataTemplate>
                                     <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8">
                                         <TextBlock Grid.Column="0" Text="{Binding Key}" FontWeight="SemiBold"/>
-                                        <TextBlock Grid.Column="1" Text="{Binding Value}" 
+                                        <TextBlock Grid.Column="1" Text="{Binding Value}"
+                                                   Foreground="{DynamicResource PrimaryBrush}" FontWeight="Bold"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
+                <!-- Ingredient Usage -->
+                <Border Classes="RitualOSCard">
+                    <StackPanel>
+                        <TextBlock Text="Ingredient Usage" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+                        <ItemsControl ItemsSource="{Binding IngredientUsage}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                                        <TextBlock Grid.Column="0" Text="{Binding Key}" FontWeight="SemiBold"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Value}"
                                                    Foreground="{DynamicResource PrimaryBrush}" FontWeight="Bold"/>
                                     </Grid>
                                 </DataTemplate>

--- a/src/Views/MainShellView.axaml
+++ b/src/Views/MainShellView.axaml
@@ -47,7 +47,19 @@
         <KeyBinding Gesture="Alt+0" Command="{Binding SetTabCommand}" CommandParameter="9"/>
     </UserControl.KeyBindings>
 
-    <TabControl SelectedIndex="{Binding SelectedTabIndex}">
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+            <TextBlock Text="Recent Templates" FontSize="16" FontWeight="Bold"/>
+            <ItemsControl ItemsSource="{Binding RecentTemplateNames}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding}"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
+        <TabControl SelectedIndex="{Binding SelectedTabIndex}">
         <TabItem Header="Inventory" AutomationProperties.Name="Inventory Tab">
             <views:InventoryView DataContext="{Binding InventoryViewModel}"/>
         </TabItem>
@@ -81,5 +93,9 @@
         <TabItem Header="Dream Parser" AutomationProperties.Name="Dream Parser Tab">
             <views:DreamParserView DataContext="{Binding DreamParserViewModel}"/>
         </TabItem>
+        <TabItem Header="Tarot" AutomationProperties.Name="Tarot Tab">
+            <views:TarotView DataContext="{Binding TarotViewModel}"/>
+        </TabItem>
     </TabControl>
+    </DockPanel>
 </UserControl>

--- a/src/Views/TarotView.axaml
+++ b/src/Views/TarotView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:RitualOS.ViewModels"
+             x:Class="RitualOS.Views.TarotView">
+    <UserControl.DataContext>
+        <vm:TarotViewModel />
+    </UserControl.DataContext>
+    <StackPanel Spacing="10" Margin="10">
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <Button Content="Draw 1" Command="{Binding DrawOneCommand}"/>
+            <Button Content="Draw 3" Command="{Binding DrawThreeCommand}"/>
+            <Button Content="Full Spread" Command="{Binding DrawFullCommand}"/>
+        </StackPanel>
+        <ItemsControl ItemsSource="{Binding DrawnCards}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Margin="5" Background="#2A1B3D">
+                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Description}"/>
+                        <TextBlock Text="Upright: {Binding MeaningUp}"/>
+                        <TextBlock Text="Reversed: {Binding MeaningRev}"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </StackPanel>
+</UserControl>

--- a/src/Views/TarotView.axaml.cs
+++ b/src/Views/TarotView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace RitualOS.Views
+{
+    public partial class TarotView : UserControl
+    {
+        public TarotView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Views/ThemePickerWindow.axaml
+++ b/src/Views/ThemePickerWindow.axaml
@@ -1,0 +1,16 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:RitualOS.ViewModels"
+        x:Class="RitualOS.Views.ThemePickerWindow"
+        Width="400" Height="300" Title="Theme Picker">
+    <Window.DataContext>
+        <vm:ThemeViewModel />
+    </Window.DataContext>
+    <StackPanel Margin="20" Spacing="10">
+        <TextBlock Text="Preview Themes" FontSize="16" HorizontalAlignment="Center"/>
+        <ComboBox ItemsSource="{Binding AvailableThemes}" SelectedItem="{Binding SelectedTheme}" />
+        <Border Background="{DynamicResource BackgroundBrush}" Padding="15" CornerRadius="6">
+            <TextBlock Text="This is a preview" Foreground="{DynamicResource PrimaryTextBrush}"/>
+        </Border>
+    </StackPanel>
+</Window>

--- a/src/Views/ThemePickerWindow.axaml.cs
+++ b/src/Views/ThemePickerWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace RitualOS.Views
+{
+    public partial class ThemePickerWindow : Window
+    {
+        public ThemePickerWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Views/ThemeSwitcher.axaml
+++ b/src/Views/ThemeSwitcher.axaml
@@ -6,6 +6,9 @@
         <vm:ThemeViewModel />
     </UserControl.DataContext>
 
-    <ComboBox ItemsSource="{Binding AvailableThemes}"
-              SelectedItem="{Binding SelectedTheme}" />
+    <StackPanel Spacing="6">
+        <ComboBox ItemsSource="{Binding AvailableThemes}"
+                  SelectedItem="{Binding SelectedTheme}" />
+        <Button Content="Open Theme Picker" Click="OpenPicker_Click" />
+    </StackPanel>
 </UserControl>

--- a/src/Views/ThemeSwitcher.axaml.cs
+++ b/src/Views/ThemeSwitcher.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace RitualOS.Views
 {
@@ -8,5 +9,11 @@ namespace RitualOS.Views
         {
             InitializeComponent();
         }
+
+        private void OpenPicker_Click(object? sender, RoutedEventArgs e)
+        {
+            var picker = new ThemePickerWindow();
+            picker.Show();
+        }
     }
-} 
+}

--- a/src/Views/Wizards/ImportExportWizard.axaml
+++ b/src/Views/Wizards/ImportExportWizard.axaml
@@ -1,0 +1,20 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:RitualOS.ViewModels.Wizards"
+             x:Class="RitualOS.Views.Wizards.ImportExportWizard">
+    <UserControl.DataContext>
+        <vm:ImportExportWizardViewModel />
+    </UserControl.DataContext>
+
+    <StackPanel Spacing="10" Margin="20">
+        <TextBlock Text="Import Ritual Logs" FontSize="18" FontWeight="Bold"/>
+        <TextBox Text="{Binding ImportPath}" Watermark="Path to log file"/>
+        <Button Content="Import" Command="{Binding ImportCommand}" Classes="RitualOSButton"/>
+
+        <Separator Margin="0,10"/>
+
+        <TextBlock Text="Export All Data" FontSize="18" FontWeight="Bold"/>
+        <TextBox Text="{Binding ExportPath}" Watermark="Output path"/>
+        <Button Content="Export" Command="{Binding ExportCommand}" Classes="RitualOSButton"/>
+    </StackPanel>
+</UserControl>

--- a/src/Views/Wizards/ImportExportWizard.axaml.cs
+++ b/src/Views/Wizards/ImportExportWizard.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace RitualOS.Views.Wizards
+{
+    public partial class ImportExportWizard : UserControl
+    {
+        public ImportExportWizard()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
### PR #XXX – Add community templates and tarot viewer
**Author:** Codex
**Feature/Component Affected:** MainShellView, Tarot features, docs

#### 🔧 Actions Taken:
- [x] Created three new ritual templates in `samples/ritual_templates`
- [x] Introduced `TemplateSharingService` for offline template sharing
- [x] Added Tarot deck data and a new tarot viewer tab
- [x] Highlight recent templates on the dashboard via `MainShellViewModel`
- [x] Updated roadmap and README links

#### 📜 Intention Behind Changes:
These updates complete the roadmap’s community templates section and provide an offline tarot spread viewer. Users can explore sample rituals, share templates as files, and pull tarot cards without needing online resources.

#### 🧠 Notes for Future You:
The tarot card dataset is lightweight but covers the full deck. Future iterations might add fancier layouts or card graphics.

#### 🧪 Testing Summary:
- [x] `dotnet build RitualOS.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_6879b90efe288332abccf00d6b7475c5