### PR TITLE
Add Cat Easter Egg with SVG cat face

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
     <PackageReference Include="VersOne.Epub" Version="3.3.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.0.0" />
   </ItemGroup>
   
   <ItemGroup>
@@ -124,6 +125,8 @@
     <Compile Include="src\Views\DreamParserView.axaml.cs" />
     <Compile Include="src\Views\TarotView.axaml.cs" />
     <Compile Include="src\Views\MagicSchoolsView.axaml.cs" />
+    <Compile Include="src\Views\CatWindow.axaml.cs" />
+    <Compile Include="src\ViewModels\CatViewModel.cs" />
     <Compile Include="src\Views\WelcomeView.axaml.cs" />
     <Compile Include="src\ViewModels\WelcomeViewModel.cs" />
     <Compile Include="components\MagicalProgressBar.axaml.cs" />
@@ -131,6 +134,7 @@
 
   <ItemGroup>
     <None Include="assets\tarot\tarot_cards.json" CopyToOutputDirectory="PreserveNewest" />
+    <AvaloniaResource Include="assets\catface.svg" />
   </ItemGroup>
 
 </Project>

--- a/assets/catface.svg
+++ b/assets/catface.svg
@@ -1,0 +1,12 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="80" fill="#FFDAB9" />
+  <circle cx="70" cy="80" r="20" fill="black" />
+  <circle cx="130" cy="80" r="20" fill="black" />
+  <path d="M60 120 Q100 150 140 120" fill="none" stroke="black" stroke-width="10" />
+  <path d="M80 60 Q100 40 120 60" fill="none" stroke="black" stroke-width="5" />
+  <path d="M80 70 Q100 50 120 70" fill="none" stroke="black" stroke-width="5" />
+  <path d="M80 80 Q100 60 120 80" fill="none" stroke="black" stroke-width="5" />
+  <path d="M80 60 Q100 80 120 60" fill="none" stroke="black" stroke-width="5" />
+  <path d="M80 70 Q100 90 120 70" fill="none" stroke="black" stroke-width="5" />
+  <path d="M80 80 Q100 100 120 80" fill="none" stroke="black" stroke-width="5" />
+</svg>

--- a/src/Models/MagicSchool.cs
+++ b/src/Models/MagicSchool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace RitualOS.Models
 {
@@ -11,5 +12,6 @@ namespace RitualOS.Models
         public string Overview { get; set; } = string.Empty;
         public string CommonPractices { get; set; } = string.Empty;
         public string WhoIsItFor { get; set; } = string.Empty;
+        public List<string> Keywords { get; set; } = new();
     }
 }

--- a/src/ViewModels/CatViewModel.cs
+++ b/src/ViewModels/CatViewModel.cs
@@ -1,0 +1,21 @@
+// ASCII art cat view model start
+//   /_/\  
+//  ( o.o ) 
+//  > ^ <
+namespace RitualOS.ViewModels
+{
+    public partial class CatViewModel : ViewModelBase
+    {
+        // ASCII art cat view model middle
+        //  /| |\
+        //  /| | \
+        public CatViewModel()
+        {
+            // Just a playful placeholder
+        }
+
+        // ASCII art cat view model end
+        //   _/| |_
+        //  /  | |  \
+    }
+}

--- a/src/ViewModels/MagicSchoolsViewModel.cs
+++ b/src/ViewModels/MagicSchoolsViewModel.cs
@@ -1,20 +1,123 @@
 using System.Collections.ObjectModel;
 using RitualOS.Models;
+using RitualOS.Helpers;
+using RitualOS.Services;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Input;
 
+// ASCII art cat shape start
+//   /_/\  
+//  ( o.o ) 
+//  > ^ <
 namespace RitualOS.ViewModels
 {
     /// <summary>
-    /// Provides a library of magical and occult schools for reference. 🧙‍♂️
+    /// Provides a comprehensive library of magical and occult schools for reference and exploration. 🧙‍♂️
     /// </summary>
     public class MagicSchoolsViewModel : ViewModelBase
     {
         public ObservableCollection<MagicSchool> Schools { get; } = new();
+        public ObservableCollection<MagicSchool> FilteredSchools { get; } = new();
+        public RelayCommand OpenDocCommand { get; }
+        public RelayCommand FilterCommand { get; }
 
+        private string _filterText = string.Empty;
+        public string FilterText
+        {
+            get => _filterText;
+            set
+            {
+                if (_filterText != value)
+                {
+                    _filterText = value;
+                    OnPropertyChanged();
+                    ApplyFilter();
+                    CheckEasterEgg();
+                }
+            }
+        }
+
+        // ASCII art cat shape middle
+        //  /| |\
+        //  /| | \
         public MagicSchoolsViewModel()
         {
             LoadSchools();
+            OpenDocCommand = new RelayCommand(param =>
+            {
+                if (param is string path)
+                {
+                    OpenDoc(path);
+                }
+            });
+            FilterCommand = new RelayCommand(param =>
+            {
+                FilterText = param as string ?? string.Empty;
+            });
+            FilteredSchools = new ObservableCollection<MagicSchool>(Schools); // Initial full list
         }
 
+        private void OpenDoc(string path)
+        {
+            var full = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path);
+            if (File.Exists(full))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = full,
+                        UseShellExecute = true
+                    });
+                }
+                catch (Exception ex)
+                {
+                    LoggingService.Error($"Failed to open document {path}: {ex.Message}");
+                }
+            }
+            else
+            {
+                LoggingService.Warn($"Document not found at {full}");
+            }
+        }
+
+        private void ApplyFilter()
+        {
+            if (string.IsNullOrWhiteSpace(FilterText))
+            {
+                FilteredSchools.Clear();
+                foreach (var school in Schools)
+                {
+                    FilteredSchools.Add(school);
+                }
+            }
+            else
+            {
+                FilteredSchools.Clear();
+                var lowerFilter = FilterText.ToLowerInvariant();
+                foreach (var school in Schools.Where(s => s.Keywords.Any(k => k.ToLowerInvariant().Contains(lowerFilter)) ||
+                                                         s.Name.ToLowerInvariant().Contains(lowerFilter)))
+                {
+                    FilteredSchools.Add(school);
+                }
+            }
+        }
+
+        private void CheckEasterEgg()
+        {
+            if (FilterText?.ToLowerInvariant() == "cat")
+            {
+                new RitualOS.Views.CatWindow().Show();
+                FilterText = string.Empty; // Reset to hide the trigger
+            }
+        }
+
+        // ASCII art cat shape end
+        //   _/| |_
+        //  /  | |  \
         private void LoadSchools()
         {
             // A small sampling of traditions. Expand as desired!
@@ -23,7 +126,8 @@ namespace RitualOS.ViewModels
                 Name = "Wicca",
                 Overview = "Wicca is a modern pagan religion focused on nature worship and ritual magic. It was popularized in the 1950s and emphasizes balance between feminine and masculine energies.",
                 CommonPractices = "Sabbats, esbat moon rituals, spellcraft with herbs and candles.",
-                WhoIsItFor = "Seekers drawn to earth-centered spirituality and structured ritual." 
+                WhoIsItFor = "Seekers drawn to earth-centered spirituality and structured ritual.",
+                Keywords = new() { "wicca", "pagan", "nature" }
             });
 
             Schools.Add(new MagicSchool
@@ -31,7 +135,8 @@ namespace RitualOS.ViewModels
                 Name = "Haitian Vodou",
                 Overview = "An African diasporic religion blending West African traditions with Catholicism, honoring spirits called lwa.",
                 CommonPractices = "Spirit possession, drumming, dance, and offerings to the lwa.",
-                WhoIsItFor = "Communities with ancestral ties to Haiti and those interested in syncretic Afro-Caribbean practices." 
+                WhoIsItFor = "Communities with ancestral ties to Haiti and those interested in syncretic Afro-Caribbean practices.",
+                Keywords = new() { "vodou", "lwa", "haiti" }
             });
 
             Schools.Add(new MagicSchool
@@ -39,7 +144,8 @@ namespace RitualOS.ViewModels
                 Name = "Hoodoo",
                 Overview = "A system of African American folk magic rooted in ancestral practices and herbal knowledge.",
                 CommonPractices = "Candle work, mojo bags, and protection rituals.",
-                WhoIsItFor = "Practitioners seeking pragmatic spellwork blended with Christian folk traditions." 
+                WhoIsItFor = "Practitioners seeking pragmatic spellwork blended with Christian folk traditions.",
+                Keywords = new() { "hoodoo", "folk" }
             });
 
             Schools.Add(new MagicSchool
@@ -47,7 +153,8 @@ namespace RitualOS.ViewModels
                 Name = "Chaos Magic",
                 Overview = "A modern approach that treats belief as a tool and encourages using whatever works to achieve results.",
                 CommonPractices = "Sigil creation, meditation, and personalized ritual experiments.",
-                WhoIsItFor = "Experimenters who value flexibility over tradition." 
+                WhoIsItFor = "Experimenters who value flexibility over tradition.",
+                Keywords = new() { "chaos", "sigil" }
             });
 
             Schools.Add(new MagicSchool
@@ -55,7 +162,8 @@ namespace RitualOS.ViewModels
                 Name = "Hermeticism",
                 Overview = "A philosophical and spiritual tradition based on writings attributed to Hermes Trismegistus, encompassing alchemy and astrology.",
                 CommonPractices = "Ritual magic, study of the Hermetica, and contemplative meditation.",
-                WhoIsItFor = "Occult students interested in historic Western esotericism." 
+                WhoIsItFor = "Occult students interested in historic Western esotericism.",
+                Keywords = new() { "hermetic", "alchemy" }
             });
 
             Schools.Add(new MagicSchool
@@ -63,7 +171,8 @@ namespace RitualOS.ViewModels
                 Name = "Thelema",
                 Overview = "Founded by Aleister Crowley, Thelema teaches discovering one's True Will and honors several Thelemic deities.",
                 CommonPractices = "Ceremonial rites, yoga, and the study of Crowley's texts including The Book of the Law.",
-                WhoIsItFor = "Those drawn to ceremonial magic and personal spiritual liberation." 
+                WhoIsItFor = "Those drawn to ceremonial magic and personal spiritual liberation.",
+                Keywords = new() { "thelema", "crowley" }
             });
 
             Schools.Add(new MagicSchool
@@ -71,7 +180,8 @@ namespace RitualOS.ViewModels
                 Name = "Orgonite Work",
                 Overview = "Inspired by Wilhelm Reich's concept of orgone energy, practitioners craft resin, metal, and crystal devices to balance subtle energies.",
                 CommonPractices = "Creating orgonite pieces, meditating with orgone accumulators, gifting pieces to the environment.",
-                WhoIsItFor = "Energy workers and tinkerers exploring alternative healing concepts." 
+                WhoIsItFor = "Energy workers and tinkerers exploring alternative healing concepts.",
+                Keywords = new() { "orgone", "energy" }
             });
 
             Schools.Add(new MagicSchool
@@ -79,7 +189,8 @@ namespace RitualOS.ViewModels
                 Name = "Technomancy",
                 Overview = "A hybrid practice blending magical intent with modern technology, often in a playful or experimental manner.",
                 CommonPractices = "Sigils encoded in QR codes, using computers or electronics as ritual tools.",
-                WhoIsItFor = "Mages who love gadgets and the intersection of tech with mysticism." 
+                WhoIsItFor = "Mages who love gadgets and the intersection of tech with mysticism.",
+                Keywords = new() { "tech", "gadgets" }
             });
         }
     }

--- a/src/Views/CatWindow.axaml
+++ b/src/Views/CatWindow.axaml
@@ -1,0 +1,27 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:RitualOS.ViewModels"
+        x:Class="RitualOS.Views.CatWindow"
+        Width="300" Height="300"
+        WindowStartupLocation="CenterScreen"
+        Title="Meow! Easter Egg!">
+    <!-- ASCII art cat window start
+       /_/\  
+      ( ^.^ ) 
+      > ^ <
+    -->
+    <Window.DataContext>
+        <vm:CatViewModel />
+    </Window.DataContext>
+    <Canvas>
+        <!-- Simple SVG cat face -->
+        <Image
+            Canvas.Left="50" Canvas.Top="50"
+            Width="200" Height="200"
+            Source="avares://RitualOS/assets/catface.svg" />
+    </Canvas>
+    <!-- ASCII art cat window end
+       _/| |_
+      /  | |  \
+    -->
+</Window>

--- a/src/Views/CatWindow.axaml.cs
+++ b/src/Views/CatWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+
+// ASCII art cat code-behind start
+//   /_/\  
+//  ( ^.^ ) 
+//  > ^ <
+namespace RitualOS.Views
+{
+    public partial class CatWindow : Window
+    {
+        // ASCII art cat code-behind middle
+        //  /| |\
+        //  /| | \
+        public CatWindow()
+        {
+            InitializeComponent();
+        }
+
+        // ASCII art cat code-behind end
+        //   _/| |_
+        //  /  | |  \
+    }
+}

--- a/src/Views/MagicSchoolsView.axaml
+++ b/src/Views/MagicSchoolsView.axaml
@@ -5,18 +5,24 @@
     <UserControl.DataContext>
         <vm:MagicSchoolsViewModel />
     </UserControl.DataContext>
-    <ScrollViewer Margin="10">
-        <ItemsControl ItemsSource="{Binding Schools}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Margin="0,0,0,20">
-                        <TextBlock Text="{Binding Name}" FontSize="18" FontWeight="Bold"/>
-                        <TextBlock Text="{Binding Overview}" TextWrapping="Wrap" Margin="0,5,0,0"/>
-                        <TextBlock Text="Practices: {Binding CommonPractices}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                        <TextBlock Text="Who is it for: {Binding WhoIsItFor}" TextWrapping="Wrap" Margin="0,2,0,0"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-    </ScrollViewer>
+    <DockPanel Margin="10">
+        <TextBox Watermark="Filter magical schools..."
+                 DockPanel.Dock="Top"
+                 Margin="0,0,0,10"
+                 Text="{Binding FilterText, Mode=TwoWay}" />
+        <ScrollViewer>
+            <ItemsControl ItemsSource="{Binding FilteredSchools}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,0,0,20">
+                            <TextBlock Text="{Binding Name}" FontSize="18" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Overview}" TextWrapping="Wrap" Margin="0,5,0,0"/>
+                            <TextBlock Text="Practices: {Binding CommonPractices}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                            <TextBlock Text="Who is it for: {Binding WhoIsItFor}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
 </UserControl>


### PR DESCRIPTION
### PR #XXX – Add Cat Easter Egg
**Author:** Codex
**Feature/Component Affected:** MagicSchoolsViewModel.cs, CatWindow

#### 🔧 Actions Taken:
- [x] Added CatWindow with playful SVG cat face
- [x] Introduced CatViewModel
- [x] Extended MagicSchoolsViewModel with filter logic and Easter egg trigger
- [x] Updated MagicSchool model with `Keywords`
- [x] Included catface.svg asset and project references

#### 📜 Intention Behind Changes:
Injects a light-hearted Easter egg into RitualOS. Typing `cat` in the Magic Schools filter pops up a special window showcasing a feline SVG. This encourages exploration and adds fun to the experience.

#### 🧠 Notes for Future You:
The SVG support uses Avalonia.Svg.Skia; ensure the package stays aligned with other Avalonia versions. More keywords or schools can be added later for richer filtering.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual UI testing not performed due to environment constraints
- No additional edge cases validated

------
https://chatgpt.com/codex/tasks/task_e_687a5b8635e48332b663b3072d32f624