### PR TITLE
Fix MagicSchools doc viewer

### DIFF
--- a/src/Models/MagicSchool.cs
+++ b/src/Models/MagicSchool.cs
@@ -10,7 +10,11 @@ namespace RitualOS.Models
         public string Name { get; set; } = string.Empty;
         public string Overview { get; set; } = string.Empty;
         public string CommonPractices { get; set; } = string.Empty;
+        public string HistoricalContext { get; set; } = string.Empty;
         public string WhoIsItFor { get; set; } = string.Empty;
+        public string NotableFigures { get; set; } = string.Empty;
+        public string RecommendedReadings { get; set; } = string.Empty;
+        public string[] Keywords { get; set; } = Array.Empty<string>();
         public string? InfoPath { get; set; }
     }
 }

--- a/src/ViewModels/MainShellViewModel.cs
+++ b/src/ViewModels/MainShellViewModel.cs
@@ -41,7 +41,12 @@ namespace RitualOS.ViewModels
             AnalyticsViewModel = new AnalyticsViewModel(analyticsService, userSettingsService);
             DreamParserViewModel = new DreamParserViewModel(dreamParserService, userSettingsService);
             TarotViewModel = new TarotViewModel();
-            MagicSchoolsViewModel = new MagicSchoolsViewModel();
+            MagicSchoolsViewModel = new MagicSchoolsViewModel(path =>
+            {
+                DocumentViewerViewModel.DocumentPath = path;
+                DocumentViewerViewModel.LoadDocumentCommand.Execute(null);
+                SelectedTabIndex = 5; // Switch to Documents tab
+            });
 
             LoadRecentTemplates();
 

--- a/src/Views/MagicSchoolsView.axaml
+++ b/src/Views/MagicSchoolsView.axaml
@@ -12,7 +12,7 @@
     <StackPanel Margin="10">
         <!-- Filter Controls -->
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,0,10,0" PlaceholderText="Filter by name or keyword..."/>
+            <TextBox Text="{Binding FilterText}" Width="200" Margin="0,0,10,0" Watermark="Filter by name or keyword..."/>
             <Button Content="Wicca" Command="{Binding FilterCommand}" CommandParameter="wicca" Margin="0,0,5,0"/>
             <Button Content="Vodou" Command="{Binding FilterCommand}" CommandParameter="vodou" Margin="0,0,5,0"/>
             <Button Content="Hoodoo" Command="{Binding FilterCommand}" CommandParameter="hoodoo" Margin="0,0,5,0"/>


### PR DESCRIPTION
### PR # – Open docs in app
**Author:** Codex
**Feature/Component Affected:** MagicSchoolsViewModel.cs, MainShellViewModel.cs

#### 🔧 Actions Taken:
- [x] Refactored document opening logic
- [x] Updated UI binding for filter text
- [x] Added missing properties to MagicSchool model
- [x] Connected MagicSchools docs to DocumentViewer tab

#### 📜 Intention Behind Changes:
Opening reference docs externally was fragile. Now clicking **More Info** loads the markdown directly in the app's DocumentViewer and switches to the Documents tab. This keeps docs bundled with the UI and sets the stage for richer in-app help.

#### 🧠 Notes for Future You:
This update uses an action callback to coordinate between view models. Consider a more formal navigation service later.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual UI testing not performed in CI
- Known issues: Several warning messages still appear during build due to nullable fields.

------
https://chatgpt.com/codex/tasks/task_e_687a5beaa09c83328a85907c4b551cd3