### PR TITLE
Fix build by adjusting command types

### DIFF
--- a/src/ViewModels/DocumentViewerViewModel.cs
+++ b/src/ViewModels/DocumentViewerViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using RitualOS.Models;
@@ -72,10 +73,20 @@ namespace RitualOS.ViewModels
                 mainWindow = desktop.MainWindow;
             }
 
-            var result = await TopLevel.GetTopLevel(mainWindow)?.StorageProvider.OpenFilePickerAsync(options);
+            IReadOnlyList<IStorageFile>? result = null;
+            var topLevel = TopLevel.GetTopLevel(mainWindow);
+            if (topLevel?.StorageProvider != null)
+            {
+                result = await topLevel.StorageProvider.OpenFilePickerAsync(options);
+            }
+
             if (result != null && result.Count > 0)
             {
-                DocumentPath = result[0].Path.LocalPath;
+                var item = result[0];
+                if (item.Path != null)
+                {
+                    DocumentPath = item.Path.LocalPath;
+                }
             }
         }
 

--- a/src/ViewModels/MagicSchoolsViewModel.cs
+++ b/src/ViewModels/MagicSchoolsViewModel.cs
@@ -23,7 +23,7 @@ namespace RitualOS.ViewModels
         public ObservableCollection<MagicSchool> FilteredSchools { get; } = new();
         public RelayCommand OpenDocCommand { get; }
         private readonly Action<string>? _openDocAction;
-        public RelayCommand<string> FilterCommand { get; }
+        public RelayCommand FilterCommand { get; }
 
         private string _filterText = string.Empty;
         public string FilterText
@@ -60,9 +60,10 @@ namespace RitualOS.ViewModels
                     OpenDoc(path);
                 }
             });
-            FilterCommand = new RelayCommand<string>(keyword =>
+            // RelayCommand without generics - we cast the parameter safely 💫
+            FilterCommand = new RelayCommand(param =>
             {
-                FilterText = keyword ?? string.Empty;
+                FilterText = param as string ?? string.Empty;
             });
             FilteredSchools = new ObservableCollection<MagicSchool>(Schools); // Initial full list
         }

--- a/src/ViewModels/MainShellViewModel.cs
+++ b/src/ViewModels/MainShellViewModel.cs
@@ -14,7 +14,7 @@ namespace RitualOS.ViewModels
 {
     public class MainShellViewModel : ViewModelBase
     {
-        private ViewModelBase _currentViewModel;
+        private ViewModelBase _currentViewModel = null!;
         private int _selectedTabIndex;
         public RelayCommand SetTabCommand { get; }
         public ObservableCollection<string> RecentTemplateNames { get; } = new();

--- a/src/ViewModels/Wizards/RitualTemplateBuilderViewModel.cs
+++ b/src/ViewModels/Wizards/RitualTemplateBuilderViewModel.cs
@@ -98,35 +98,35 @@ namespace RitualOS.ViewModels.Wizards
         public string[] MoonPhaseOptions { get; } = { "New Moon", "Waxing Crescent", "First Quarter", "Waxing Gibbous", "Full Moon", "Waning Gibbous", "Last Quarter", "Waning Crescent" };
 
         // Commands
-        private ICommand _addStepCommand;
+        private ICommand _addStepCommand = null!;
         public ICommand AddStepCommand { get => _addStepCommand; private set { _addStepCommand = value; OnPropertyChanged(); } }
-        private ICommand _removeStepCommand;
+        private ICommand _removeStepCommand = null!;
         public ICommand RemoveStepCommand { get => _removeStepCommand; private set { _removeStepCommand = value; OnPropertyChanged(); } }
-        private ICommand _moveStepUpCommand;
+        private ICommand _moveStepUpCommand = null!;
         public ICommand MoveStepUpCommand { get => _moveStepUpCommand; private set { _moveStepUpCommand = value; OnPropertyChanged(); } }
-        private ICommand _moveStepDownCommand;
+        private ICommand _moveStepDownCommand = null!;
         public ICommand MoveStepDownCommand { get => _moveStepDownCommand; private set { _moveStepDownCommand = value; OnPropertyChanged(); } }
-        private ICommand _saveTemplateCommand;
+        private ICommand _saveTemplateCommand = null!;
         public ICommand SaveTemplateCommand { get => _saveTemplateCommand; private set { _saveTemplateCommand = value; OnPropertyChanged(); } }
-        private ICommand _loadTemplateCommand;
+        private ICommand _loadTemplateCommand = null!;
         public ICommand LoadTemplateCommand { get => _loadTemplateCommand; private set { _loadTemplateCommand = value; OnPropertyChanged(); } }
-        private ICommand _clearTemplateCommand;
+        private ICommand _clearTemplateCommand = null!;
         public ICommand ClearTemplateCommand { get => _clearTemplateCommand; private set { _clearTemplateCommand = value; OnPropertyChanged(); } }
-        private ICommand _addToolCommand;
+        private ICommand _addToolCommand = null!;
         public ICommand AddToolCommand { get => _addToolCommand; private set { _addToolCommand = value; OnPropertyChanged(); } }
-        private ICommand _removeToolCommand;
+        private ICommand _removeToolCommand = null!;
         public ICommand RemoveToolCommand { get => _removeToolCommand; private set { _removeToolCommand = value; OnPropertyChanged(); } }
-        private ICommand _addSpiritCommand;
+        private ICommand _addSpiritCommand = null!;
         public ICommand AddSpiritCommand { get => _addSpiritCommand; private set { _addSpiritCommand = value; OnPropertyChanged(); } }
-        private ICommand _removeSpiritCommand;
+        private ICommand _removeSpiritCommand = null!;
         public ICommand RemoveSpiritCommand { get => _removeSpiritCommand; private set { _removeSpiritCommand = value; OnPropertyChanged(); } }
-        private ICommand _addChakraCommand;
+        private ICommand _addChakraCommand = null!;
         public ICommand AddChakraCommand { get => _addChakraCommand; private set { _addChakraCommand = value; OnPropertyChanged(); } }
-        private ICommand _removeChakraCommand;
+        private ICommand _removeChakraCommand = null!;
         public ICommand RemoveChakraCommand { get => _removeChakraCommand; private set { _removeChakraCommand = value; OnPropertyChanged(); } }
-        private ICommand _addElementCommand;
+        private ICommand _addElementCommand = null!;
         public ICommand AddElementCommand { get => _addElementCommand; private set { _addElementCommand = value; OnPropertyChanged(); } }
-        private ICommand _removeElementCommand;
+        private ICommand _removeElementCommand = null!;
         public ICommand RemoveElementCommand { get => _removeElementCommand; private set { _removeElementCommand = value; OnPropertyChanged(); } }
 
         // INotifyDataErrorInfo implementation

--- a/src/Views/MagicSchoolsView.axaml
+++ b/src/Views/MagicSchoolsView.axaml
@@ -12,10 +12,10 @@
     <DockPanel Margin="10">
         <!-- Filter Controls -->
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,10">
-            <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" 
-                     Width="200" 
-                     Margin="0,0,10,0" 
-                     PlaceholderText="Filter by name or keyword..." />
+            <TextBox Text="{Binding FilterText}"
+                     Width="200"
+                     Margin="0,0,10,0"
+                     Watermark="Filter by name or keyword..." />
             <Button Content="Wicca" Command="{Binding FilterCommand}" CommandParameter="wicca" Margin="0,0,5,0"/>
             <Button Content="Vodou" Command="{Binding FilterCommand}" CommandParameter="vodou" Margin="0,0,5,0"/>
             <Button Content="Hoodoo" Command="{Binding FilterCommand}" CommandParameter="hoodoo" Margin="0,0,5,0"/>


### PR DESCRIPTION
### PR – Fix build error and reduce warnings
**Author:** Codex
**Feature/Component Affected:** MagicSchoolsViewModel.cs, MagicSchoolsView.axaml, DocumentViewerViewModel.cs, MainShellViewModel.cs, RitualTemplateBuilderViewModel.cs

#### 🔧 Actions Taken:
- [x] Fixed use of generic `RelayCommand` causing CS0308
- [x] Updated placeholder and binding in `MagicSchoolsView.axaml`
- [x] Added null checks and `System.Linq` usage for document picker
- [x] Initialized commands to avoid nullable warnings
- [x] Assigned main view model field with null-forgiving operator

#### 📜 Intention Behind Changes:
Resolve build failure and tame several warnings so the project compiles cleanly again. These tweaks make command usage consistent and handle potential nulls during file selection, smoothing out the development experience.

#### 🧠 Notes for Future You:
Remaining warnings are related to async methods without awaits—they'll need a deeper look later.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual testing not performed
- Known issues: remaining async warnings


------
https://chatgpt.com/codex/tasks/task_e_687a6719d9f0833290eea027603050c7