### PR TITLE
Fix build errors and update packages

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Avalonia.Headless" Version="11.0.10" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
-    <PackageReference Include="QuestPDF" Version="2024.1.4" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
     <PackageReference Include="VersOne.Epub" Version="3.3.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.62" />
     <PackageReference Include="Avalonia.Svg.Skia" Version="11.0.0" />

--- a/src/Models/Symbol.cs
+++ b/src/Models/Symbol.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Views/GrimoireEntryEditor.axaml
+++ b/src/Views/GrimoireEntryEditor.axaml
@@ -4,8 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:RitualOS.ViewModels"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
-        x:Class="RitualOS.Views.GrimoireEntryEditor"
-        x:DataType="vm:GrimoireEntryEditorViewModel"
         Title="Grimoire Entry Editor"
         Width="800" Height="600"
         Icon="/assets/icons/grimoire.ico"
@@ -131,7 +129,7 @@
                 <!-- Tags and Symbols -->
                 <Border Classes="section-card">
                     <StackPanel Spacing="12">
-                        <TextBlock Text="🏷️ Tags & Symbols" FontSize="16" FontWeight="Bold" Foreground="#DAA520"/>
+                        <TextBlock Text="🏷️ Tags &amp; Symbols" FontSize="16" FontWeight="Bold" Foreground="#DAA520"/>
                         
                         <!-- Tags -->
                         <StackPanel Spacing="8">
@@ -196,8 +194,7 @@
                                 <ComboBox Grid.Column="0" ItemsSource="{Binding AvailableSymbols}"
                                           SelectedItem="{Binding SelectedSymbol}"
                                           Background="#3E3E42" Foreground="White"
-                                          BorderBrush="#8B4513" CornerRadius="4"
-                                          Watermark="Select a symbol...">
+                                          BorderBrush="#8B4513" CornerRadius="4">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding}" Foreground="White"/>
@@ -269,8 +266,7 @@
                                 <ComboBox ItemsSource="{Binding MoonPhases}"
                                           SelectedItem="{Binding MoonPhase}"
                                           Background="#3E3E42" Foreground="White"
-                                          BorderBrush="#8B4513" CornerRadius="4"
-                                          Watermark="Select moon phase...">
+                                          BorderBrush="#8B4513" CornerRadius="4">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding}" Foreground="White"/>

--- a/src/Views/GrimoireFSView.axaml
+++ b/src/Views/GrimoireFSView.axaml
@@ -4,8 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:RitualOS.ViewModels"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
-        x:Class="RitualOS.Views.GrimoireFSView"
-        x:DataType="vm:GrimoireFSViewModel"
         Title="GrimoireFS - RitualOS"
         Width="1200" Height="800"
         Icon="/assets/icons/grimoire.ico">
@@ -100,7 +98,7 @@
             <Border Grid.Column="0" Background="#252526" BorderBrush="#8B4513" BorderThickness="0,0,1,0">
                 <ScrollViewer>
                     <StackPanel Margin="16" Spacing="16">
-                        <TextBlock Text="🔍 Search & Filters" FontSize="18" FontWeight="Bold" Foreground="#DAA520"/>
+                        <TextBlock Text="🔍 Search &amp; Filters" FontSize="18" FontWeight="Bold" Foreground="#DAA520"/>
 
                         <!-- Search Box -->
                         <StackPanel Spacing="8">
@@ -180,7 +178,7 @@
                 <!-- Loading Overlay -->
                 <Border Grid.Row="0" Background="#80000000" IsVisible="{Binding IsLoading}">
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="16">
-                        <ProgressRing IsIndeterminate="True" Width="48" Height="48"/>
+                        <ProgressBar IsIndeterminate="True" Width="48" Height="4"/>
                         <TextBlock Text="Loading Grimoire..." Foreground="White" FontSize="16"/>
                     </StackPanel>
                 </Border>
@@ -195,8 +193,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Classes="grimoire-card" Width="300" Height="250"
-                                        IsSelected="{Binding IsSelected}">
+                                <Border Classes="grimoire-card" Width="300" Height="250">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>

--- a/src/Views/MediaStorageView.axaml
+++ b/src/Views/MediaStorageView.axaml
@@ -4,8 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:RitualOS.ViewModels"
         mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
-        x:Class="RitualOS.Views.MediaStorageView"
-        x:DataType="vm:MediaStorageViewModel"
         Title="Media Storage - RitualOS"
         Width="1400" Height="900"
         Icon="/assets/icons/media.ico">
@@ -58,7 +56,6 @@
             <Setter Property="Background" Value="#1E1E1E"/>
             <Setter Property="BorderBrush" Value="#DAA520"/>
             <Setter Property="BorderThickness" Value="2"/>
-            <Setter Property="BorderDashArray" Value="5,5"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="20"/>
         </Style>
@@ -114,7 +111,7 @@
             <Border Grid.Column="0" Background="#252526" BorderBrush="#8B4513" BorderThickness="0,0,1,0">
                 <ScrollViewer>
                     <StackPanel Margin="16" Spacing="16">
-                        <TextBlock Text="🔍 Search & Filters" FontSize="18" FontWeight="Bold" Foreground="#DAA520"/>
+                        <TextBlock Text="🔍 Search &amp; Filters" FontSize="18" FontWeight="Bold" Foreground="#DAA520"/>
 
                         <!-- Search Box -->
                         <StackPanel Spacing="8">
@@ -210,7 +207,7 @@
                 <!-- Loading Overlay -->
                 <Border Grid.Row="0" Background="#80000000" IsVisible="{Binding IsLoading}">
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="16">
-                        <ProgressRing IsIndeterminate="True" Width="48" Height="48"/>
+                        <ProgressBar IsIndeterminate="True" Width="48" Height="4"/>
                         <TextBlock Text="Loading Media Library..." Foreground="White" FontSize="16"/>
                     </StackPanel>
                 </Border>
@@ -225,8 +222,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Classes="media-card" Width="280" Height="320"
-                                        IsSelected="{Binding IsSelected}">
+                                <Border Classes="media-card" Width="280" Height="320">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="120"/>

--- a/src/Views/SymbolSvgViewer.axaml
+++ b/src/Views/SymbolSvgViewer.axaml
@@ -2,9 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
-             x:Class="RitualOS.Views.SymbolSvgViewer"
-             x:DataType="vm:SymbolSvgViewerViewModel">
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300">
 
     <UserControl.Styles>
         <Style Selector="Button.control-button">
@@ -78,11 +76,11 @@
                         Background="Transparent">
                     
                     <!-- SVG Content -->
-                    <Border Canvas.Left="{Binding SvgX}" 
-                            Canvas.Top="{Binding SvgY}"
-                            Width="{Binding SvgWidth}" 
-                            Height="{Binding SvgHeight}"
-                            Background="Transparent">
+                    <Grid Canvas.Left="{Binding SvgX}"
+                          Canvas.Top="{Binding SvgY}"
+                          Width="{Binding SvgWidth}"
+                          Height="{Binding SvgHeight}"
+                          Background="Transparent">
                         
                         <!-- SVG Image -->
                         <Image Name="SvgImage" 
@@ -97,7 +95,7 @@
                                    StrokeDashArray="5,5"
                                    Fill="Transparent"
                                    IsVisible="{Binding IsSelected}"/>
-                    </Border>
+                    </Grid>
                     
                     <!-- Grid Overlay (optional) -->
                     <Canvas Name="GridOverlay" 
@@ -140,7 +138,7 @@
         <!-- Loading Overlay -->
         <Border Grid.Row="1" Background="#80000000" IsVisible="{Binding IsLoading}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="16">
-                <ProgressRing IsIndeterminate="True" Width="32" Height="32"/>
+                <ProgressBar IsIndeterminate="True" Width="120" Height="4"/>
                 <TextBlock Text="Loading Symbol..." Foreground="White"/>
             </StackPanel>
         </Border>

--- a/src/Views/SymbolWikiView.axaml
+++ b/src/Views/SymbolWikiView.axaml
@@ -4,8 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:RitualOS.ViewModels"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
-        x:Class="RitualOS.Views.SymbolWikiView"
-        x:DataType="vm:SymbolWikiViewModel"
         Title="SymbolWiki - RitualOS"
         Width="1200" Height="800"
         Icon="/assets/icons/symbol_wiki.ico">
@@ -90,7 +88,7 @@
             <Border Grid.Column="0" Background="#252526" BorderBrush="#3E3E42" BorderThickness="0,0,1,0">
                 <ScrollViewer>
                     <StackPanel Margin="16" Spacing="16">
-                        <TextBlock Text="🔍 Search & Filters" FontSize="18" FontWeight="Bold" Foreground="White"/>
+                        <TextBlock Text="🔍 Search &amp; Filters" FontSize="18" FontWeight="Bold" Foreground="White"/>
 
                         <!-- Search Box -->
                         <StackPanel Spacing="8">
@@ -200,7 +198,7 @@
                 <!-- Loading Overlay -->
                 <Border Grid.Row="0" Background="#80000000" IsVisible="{Binding IsLoading}">
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="16">
-                        <ProgressRing IsIndeterminate="True" Width="48" Height="48"/>
+                        <ProgressBar IsIndeterminate="True" Width="48" Height="4"/>
                         <TextBlock Text="Loading SymbolWiki..." Foreground="White" FontSize="16"/>
                     </StackPanel>
                 </Border>
@@ -215,8 +213,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Classes="symbol-card" Width="280" Height="200"
-                                        IsSelected="{Binding IsSelected}">
+                                <Border Classes="symbol-card" Width="280" Height="200">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
### PR #XXX – Fix build errors
**Author:** Codex
**Feature/Component Affected:** RitualOS build configuration

#### 🔧 Actions Taken:
- [x] Updated QuestPDF reference to 2024.3.0
- [x] Added missing `using System` in `Symbol.cs`
- [x] Fixed XAML issues across several views (removed invalid properties, replaced unsupported controls)
- [x] Removed unused `x:Class` attributes for views without code-behind

#### 📜 Intention Behind Changes:
These tweaks resolve package mismatch warnings and Avalonia parsing errors preventing the project from compiling. Simplifying the XAML removes unsupported properties and ensures compatibility with the current Avalonia version, letting RitualOS build cleanly.

#### 🧠 Notes for Future You:
Some advanced views and services (e.g., GrimoireFS) remain excluded from compilation, so related tests currently fail. Expand compilation targets once those dependencies are complete.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- Manual UI testing: N/A
- Edge cases validated: N/A
- Known issues: Solution build still fails due to missing features in tests


------
https://chatgpt.com/codex/tasks/task_e_687b1cc633cc8332b5be22cfe976bd62