### PR TITLE
Fix build by adding service sources

### DIFF
--- a/RitualOS.csproj
+++ b/RitualOS.csproj
@@ -81,6 +81,9 @@
     <Compile Include="services\BackupService.cs" />
     <Compile Include="services\DataImportExportService.cs" />
     <Compile Include="services\PluginLoader.cs" />
+    <Compile Include="services\GrimoireFS.cs" />
+    <Compile Include="services\MediaStorageService.cs" />
+    <Compile Include="services\SymbolWikiService.cs" />
     <Compile Include="services\TarotService.cs" />
     <Compile Include="src\Behaviors\ListBoxReorderBehavior.cs" />
     <Compile Include="src\ViewModels\ClientViewModel.cs" />


### PR DESCRIPTION
### PR #XXX – Fix build errors
**Author:** Codex
**Feature/Component Affected:** `RitualOS.csproj`

#### 🔧 Actions Taken:
- [x] Added missing service class references to project file
- [ ] Refactored logic/component
- [x] Fixed build issues with tests
- [ ] Updated layout/UX/text/symbol handling/etc.

#### 📜 Intention Behind Changes:
Tests couldn't compile because `GrimoireFS`, `MediaStorageService`, and `SymbolWikiService` were not included in the project. Adding them resolves the missing type errors and allows the solution to build successfully.

#### 🧠 Notes for Future You:
No tricky spells here, just aligning project references. Future work might tighten warnings in these services.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully
- [ ] Manual UI tested
- [ ] Edge cases validated
- Known issues: warnings remain in several services but do not block build.


------
https://chatgpt.com/codex/tasks/task_e_687b94bbf1b083329e1da0006265a39b