### PR TITLE
Fix QuestPDF version warning

### DIFF
--- a/tests/RitualOS.Tests/RitualOS.Tests.csproj
+++ b/tests/RitualOS.Tests/RitualOS.Tests.csproj
@@ -20,6 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!-- Ensure tests use the same QuestPDF version as the main project -->
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
     <PackageReference Include="Avalonia.Headless" Version="11.0.10" />
   </ItemGroup>
 


### PR DESCRIPTION
### PR #XXX – Fix QuestPDF version warning
**Author:** Codex
**Feature/Component Affected:** RitualOS.Tests.csproj

#### 🔧 Actions Taken:
- [ ] Added [functionality or class]
- [ ] Refactored [logic/component]
- [x] Fixed [bug or regression]
- [ ] Updated [layout/UX/text/symbol handling/etc.]

#### 📜 Intention Behind Changes:
The solution threw a NU1603 warning complaining about an unresolved QuestPDF dependency when building the tests project. Adding an explicit `QuestPDF` reference ensures the same 2024.3.0 package is used everywhere and silences the warning.

#### 🧠 Notes for Future You:
This was a straightforward fix—no rituals required. Just keeping versions in sync so the build stays happy.

#### 🧪 Testing Summary:
- [x] Built and compiled successfully (yes)
- [ ] Manual UI tested (n/a)
- [ ] Edge cases validated (n/a)
- Known issues: none


------
https://chatgpt.com/codex/tasks/task_e_687b975cd4d883328346f0e62841a14e